### PR TITLE
release(major): v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clang-format-node",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clang-format-node",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "MIT",
       "bin": {
         "clang-format": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Node repackaging of the clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [


### PR DESCRIPTION
Bump `lumirlumir/npm-clang-format-node` from v0.0.0 to v1.0.0 :tada: