### PR TITLE
fix: excution error in linux-like os for permission. 644 to 755

### DIFF
--- a/.github/workflows/llvm-build-bump-pr.yml
+++ b/.github/workflows/llvm-build-bump-pr.yml
@@ -103,6 +103,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=MinSizeRel &&
 
             ninja -C build clang-format &&
+            chmod 755 build/bin/clang-format &&
 
             echo clang-format version info &&
 
@@ -172,6 +173,7 @@ jobs:
       - name: Build clang-format
         run: |
           ninja -C build clang-format
+          chmod 755 build/bin/clang-format
 
       - name: Debug clang-format version
         run: |


### PR DESCRIPTION
An execution error occurred in the GitHub Actions runner due to permissions for `clang-format`.

The original permission was `644`, so I changed it to `755`.

![image](https://github.com/user-attachments/assets/b37e7301-593f-4af1-ab0e-e389235a0116)
