### PR TITLE
fix: excution error in linux-like os for permission. 644 to 755 using postinstall

### DIFF
--- a/.github/workflows/llvm-build-bump-pr.yml
+++ b/.github/workflows/llvm-build-bump-pr.yml
@@ -109,7 +109,6 @@ jobs:
               -DCMAKE_BUILD_TYPE=MinSizeRel &&
 
             ninja -C build clang-format &&
-            chmod 755 build/bin/clang-format &&
 
             echo clang-format version info &&
 
@@ -179,7 +178,6 @@ jobs:
       - name: Build clang-format
         run: |
           ninja -C build clang-format
-          chmod 755 build/bin/clang-format
 
       - name: Debug clang-format version
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "clang-format-node",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "clang-format": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "prepare": "husky",
-    "postinstall": "find ./build/bin -type f -exec chmod 755 {} +",
+    "postinstall": "find ./build/bin -type f -exec chmod 755 {} + || true",
     "prepublishOnly": "npm run build",
     "build": "npx babel src -d build --no-comments --compact true --minified && cp -r src/bin build",
     "test": "npx mocha ./tests --inline-diffs true",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "scripts": {
     "prepare": "husky",
+    "postinstall": "find ./build/bin -type f -exec chmod 755 {} +",
     "prepublishOnly": "npm run build",
     "build": "npx babel src -d build --no-comments --compact true --minified && cp -r src/bin build",
     "test": "npx mocha ./tests --inline-diffs true",


### PR DESCRIPTION
Discard #6. It doesn't work. 

---

I used `postinstall` to solve this bug.

An execution error occurred in the GitHub Actions runner due to permissions for `clang-format`.

The original permission was `644`, so I changed it to `755`.

![image](https://github.com/user-attachments/assets/b37e7301-593f-4af1-ab0e-e389235a0116)
