### PR TITLE
fix: update llvm-build process for backward compatibility in GitHub Actions Runner

### DIFF
--- a/.github/workflows/llvm-build-bump-pr.yml
+++ b/.github/workflows/llvm-build-bump-pr.yml
@@ -92,9 +92,10 @@ jobs:
         run: |
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
+      # Use the oldest ubuntu image version possible for backward compatibility.
       - name: Docker run
         run: |
-          docker run --name ${{ matrix.docker.node-name }} --platform linux/${{ matrix.docker.arch }} ${{ matrix.docker.image }}/ubuntu:latest /bin/bash -c "
+          docker run --name ${{ matrix.docker.node-name }} --platform linux/${{ matrix.docker.arch }} ${{ matrix.docker.image }}/ubuntu:20.04 /bin/bash -c "
             uname -m &&
             pwd &&
 
@@ -136,8 +137,9 @@ jobs:
       matrix:
         type:
           - macos-14 # arm64 (macos-latest: arm64)
-          - macos-13 # x64 (macos-12: x64)
+          - macos-12 # x64 (macos-13: x64)
 
+    # Use the oldest version possible for backward compatibility.
     runs-on: ${{ matrix.type }}
 
     needs: [stage1]
@@ -191,7 +193,8 @@ jobs:
 
   # Windows
   stage2-build-win32:
-    runs-on: windows-latest
+    # Use the oldest version possible for backward compatibility.
+    runs-on: windows-2019
 
     needs: [stage1]
 


### PR DESCRIPTION
I fixed bugs in Windows and Linux of Github Actions runner.

In Linux, GLIBC version is not compatible.

Also in Windows, `windows-2022`(`windows-latest`) is OK. but, `windows-2019` is not compatible.

So I downgraded mac, linux, windows Image version for a better backward compatibility.