### PR TITLE
rename: ubuntu-latest to ubuntu-22.04 in llvm-build-bump-pr.yml

### DIFF
--- a/.github/workflows/llvm-build-bump-pr.yml
+++ b/.github/workflows/llvm-build-bump-pr.yml
@@ -59,7 +59,7 @@ jobs:
 
   # Linux-x64
   stage2-build-linux-x64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     needs: [stage1]
 
@@ -112,7 +112,7 @@ jobs:
 
   # Linux-qemu(cross-platform)
   stage2-build-linux-qemu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     needs: [stage1]
 


### PR DESCRIPTION
`ubuntu-latest` equals `ubuntu-22.04`. (24.09.10)