### PR TITLE
release(minor): v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clang-format-node",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clang-format-node",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Node repackaging of the clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [


### PR DESCRIPTION
Bump `lumirlumir/npm-clang-format-node` from v1.0.3 to v1.1.0 :tada: