### PR TITLE
ci(test-cross-platform): delete deprecated `macos-12`

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -19,7 +19,6 @@ jobs:
           - macos-15
           - macos-14
           - macos-13
-          - macos-12
           - ubuntu-24.04
           - ubuntu-22.04
           - windows-2022


### PR DESCRIPTION
Delete deprecated `macos-12`. See the screenshot below.

![image](https://github.com/user-attachments/assets/90e60dc5-f92c-43a9-8836-1cede82e7d93)
