### PR TITLE
feat: support JSDoc type hints using typescript's `d.ts` file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "lint-staged": "^15.2.10",
         "markdownlint-cli": "^0.42.0",
         "nyc": "^17.0.0",
-        "prettier": "^3.3.3"
+        "prettier": "^3.3.3",
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lint-staged": "^15.2.10",
     "markdownlint-cli": "^0.42.0",
     "nyc": "^17.0.0",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "typescript": "^5.6.3"
   },
   "lint-staged": {
     "*": [

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "postinstall": "test -d src && npm run build || npm run chmod",
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build --ignore **/*.test.js && cp -r src/script build && cp ../../LICENSE ../../README.md .",
+    "build": "npx babel src -d build --ignore **/*.test.js && npx tsc && cp -r src/script build && cp ../../LICENSE ../../README.md .",
     "postbuild": "npm run chmod",
     "test": "node --test",
     "chmod": "find ./src/script ./build/script -type f -exec chmod 755 {} + || true"

--- a/packages/clang-format-git-python/tsconfig.json
+++ b/packages/clang-format-git-python/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "build"
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]
+}

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "postinstall": "test -d src && npm run build || npm run chmod",
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build --ignore **/*.test.js && cp -r src/bin build && cp ../../LICENSE ../../README.md .",
+    "build": "npx babel src -d build --ignore **/*.test.js && npx tsc && cp -r src/bin build && cp ../../LICENSE ../../README.md .",
     "postbuild": "npm run chmod",
     "test": "node --test",
     "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || true"

--- a/packages/clang-format-node/tsconfig.json
+++ b/packages/clang-format-node/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "build"
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]
+}


### PR DESCRIPTION
Now we support JSDoc type hints using typescript's `d.ts` file.

It will be located in `clang-format-.../build/index.d.ts`.