### PR TITLE
feat(clang-forma-node): add new API aliases `clangFormatNodePath` and `getClangFormatNodePath`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15315,7 +15315,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
-        "clang-format": "build/cli.js"
+        "clang-format": "build/cli.js",
+        "clang-format-node": "build/cli.js"
       },
       "engines": {
         "node": ">=16"

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -9,7 +9,8 @@
     "README.md"
   ],
   "bin": {
-    "clang-format": "build/cli.js"
+    "clang-format": "build/cli.js",
+    "clang-format-node": "build/cli.js"
   },
   "keywords": [
     "clang-format",

--- a/packages/clang-format-node/src/index.js
+++ b/packages/clang-format-node/src/index.js
@@ -1,7 +1,12 @@
-const { clangFormatPath } = require('./utils/clangFormatPath');
-const { getClangFormatPath } = require('./utils/getClangFormatPath');
+const { clangFormatPath, clangFormatNodePath } = require('./utils/clangFormatPath');
+const {
+  getClangFormatPath,
+  getClangFormatNodePath,
+} = require('./utils/getClangFormatPath');
 
 module.exports = {
   clangFormatPath,
+  clangFormatNodePath,
   getClangFormatPath,
+  getClangFormatNodePath,
 };

--- a/packages/clang-format-node/src/index.test.js
+++ b/packages/clang-format-node/src/index.test.js
@@ -1,13 +1,24 @@
 const { ok } = require('node:assert');
 const { describe, it } = require('node:test');
 
-const { clangFormatPath, getClangFormatPath } = require('./index');
+const {
+  clangFormatPath,
+  clangFormatNodePath,
+  getClangFormatPath,
+  getClangFormatNodePath,
+} = require('./index');
 
 describe('index ok testing', () => {
   it('clangFormatPath should be imported correctly', () => {
     ok(clangFormatPath);
   });
+  it('clangFormatNodePath should be imported correctly', () => {
+    ok(clangFormatNodePath);
+  });
   it('getClangFormatPath should be imported correctly', () => {
     ok(getClangFormatPath);
+  });
+  it('getClangFormatNodePath should be imported correctly', () => {
+    ok(getClangFormatNodePath);
   });
 });

--- a/packages/clang-format-node/src/utils/clangFormatPath.js
+++ b/packages/clang-format-node/src/utils/clangFormatPath.js
@@ -4,9 +4,21 @@ const { getClangFormatPath } = require('./getClangFormatPath');
 
 /**
  * The ABSOLUTE path to the `clang-format` executable binary based on the OS platform and architecture.
+ *
+ * @alias `clangFormatNodePath`. See {@link clangFormatNodePath}.
+ * @version `v1.2.0` Initial release.
  */
 const clangFormatPath = getClangFormatPath(platform(), arch());
 
+/**
+ * Alias for `clangFormatPath`.
+ *
+ * @alias `clangFormatPath`. See {@link clangFormatPath}.
+ * @version `v1.2.0` Initial release.
+ */
+const clangFormatNodePath = clangFormatPath;
+
 module.exports = {
   clangFormatPath,
+  clangFormatNodePath,
 };

--- a/packages/clang-format-node/src/utils/clangFormatPath.test.js
+++ b/packages/clang-format-node/src/utils/clangFormatPath.test.js
@@ -2,11 +2,14 @@ const { strictEqual } = require('node:assert');
 const { platform, arch } = require('node:os');
 const { describe, it } = require('node:test');
 
-const { clangFormatPath } = require('./clangFormatPath');
+const { clangFormatPath, clangFormatNodePath } = require('./clangFormatPath');
 const { getClangFormatPath } = require('./getClangFormatPath');
 
 describe('clangFormatPath strictEqual testing', () => {
   it('clangFormatPath === getClangFormatPath(platform(), arch())', () => {
     strictEqual(clangFormatPath, getClangFormatPath(platform(), arch()));
+  });
+  it('clangFormatNodePath === clangFormatPath', () => {
+    strictEqual(clangFormatNodePath, clangFormatPath);
   });
 });

--- a/packages/clang-format-node/src/utils/getClangFormatPath.js
+++ b/packages/clang-format-node/src/utils/getClangFormatPath.js
@@ -12,6 +12,8 @@ const { resolve } = require('path');
  * @param {string} architecture The current system architecture. (e.g., `arm`, `arm64`, `ppc64`, `s390x`, `x64`)
  * @returns {string} The ABSOLUTE path to the `clang-format` executable binary.
  * @throws `Error` Throws an error if the executable binary is not found for the specified OS platform and architecture.
+ * @alias `getClangFormatNodePath`. See {@link getClangFormatNodePath}.
+ * @version `v1.2.0` Initial release.
  */
 function getClangFormatPath(osPlatform, architecture) {
   const clangFormatPath = resolve(
@@ -30,6 +32,15 @@ function getClangFormatPath(osPlatform, architecture) {
   return clangFormatPath;
 }
 
+/**
+ * Alias for `getClangFormatPath`.
+ *
+ * @alias `getClangFormatPath`. See {@link getClangFormatPath}.
+ * @version `v1.2.0` Initial release.
+ */
+const getClangFormatNodePath = getClangFormatPath;
+
 module.exports = {
   getClangFormatPath,
+  getClangFormatNodePath,
 };

--- a/packages/clang-format-node/src/utils/getClangFormatPath.test.js
+++ b/packages/clang-format-node/src/utils/getClangFormatPath.test.js
@@ -1,7 +1,7 @@
 const { doesNotThrow, throws } = require('node:assert');
 const { describe, it } = require('node:test');
 
-const { getClangFormatPath } = require('./getClangFormatPath');
+const { getClangFormatPath, getClangFormatNodePath } = require('./getClangFormatPath');
 
 /**
  * See possible values in {@link https://nodejs.org/api/os.html#osplatform}.
@@ -44,10 +44,12 @@ describe('getClangFormatPath doesNotThrow and throws testing', () => {
         if (allowed[osPlatform] && allowed[osPlatform].includes(architecture)) {
           doesNotThrow(() => {
             getClangFormatPath(osPlatform, architecture);
+            getClangFormatNodePath(osPlatform, architecture);
           });
         } else {
           throws(() => {
             getClangFormatPath(osPlatform, architecture);
+            getClangFormatNodePath(osPlatform, architecture);
           });
         }
       });


### PR DESCRIPTION
`clangFormatNodePath` equals `clangFormatPath`.

`getClangFormatNodePath` equals `getClangFormatPath`.