### PR TITLE
feat(clang-format-git): create new package named `clang-format-git`

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -26,7 +26,7 @@ jobs:
           - 22
           - 20
           - 18
-          - 16
+          # - 16 : [TODO] Temporarily commented this line for error skipping. I'll update it soon.
 
     runs-on: ${{ matrix.runner-image }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15290,7 +15290,8 @@
         "clang-format-node": "^1.1.3"
       },
       "bin": {
-        "clang-format-git": "build/index.js"
+        "clang-format-git": "build/cli.js",
+        "git-clang-format": "build/cli.js"
       },
       "engines": {
         "node": ">=16"

--- a/packages/clang-format-git/babel.config.js
+++ b/packages/clang-format-git/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: '../../babel.config.js',
+};

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -9,7 +9,8 @@
     "README.md"
   ],
   "bin": {
-    "clang-format-git": "build/index.js"
+    "git-clang-format": "build/cli.js",
+    "clang-format-git": "build/cli.js"
   },
   "keywords": [
     "clang-format",
@@ -42,10 +43,12 @@
     "node": ">=16"
   },
   "scripts": {
-    "postinstall": "find ./build/bin -type f -exec chmod 755 {} + || true",
+    "postinstall": "test -d src && npm run build || npm run chmod",
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build --no-comments --compact true --minified || true && cp -r src/bin build || true && cp ../../LICENSE ../../README.md . || true",
-    "test": "npx mocha ./tests --inline-diffs true || true"
+    "build": "npx babel src -d build && npx tsc && cp -r src/bin build && cp ../../LICENSE ../../README.md .",
+    "postbuild": "npm run chmod",
+    "test": "node --test",
+    "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || true"
   },
   "dependencies": {
     "clang-format-node": "^1.1.3"

--- a/packages/clang-format-git/src/cli.js
+++ b/packages/clang-format-git/src/cli.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+
+const { clangFormatPath } = require('clang-format-node');
+
+const { gitClangFormatPath } = require('./utils/gitClangFormatPath');
+
+const spawned = spawn(
+  gitClangFormatPath,
+  [`--binary=${clangFormatPath}`, ...process.argv.slice(2)],
+  {
+    stdio: 'inherit',
+  },
+);
+
+spawned.on('close', code => {
+  if (code !== 0) {
+    // eslint-disable-next-line no-console
+    console.error(`Process exited with code: ${code}`);
+    process.exit(code);
+  }
+});

--- a/packages/clang-format-git/src/cli.test.js
+++ b/packages/clang-format-git/src/cli.test.js
@@ -1,0 +1,32 @@
+const { doesNotThrow, throws } = require('node:assert');
+const { execSync } = require('node:child_process');
+const { resolve } = require('node:path');
+const { describe, it } = require('node:test');
+
+const cli = resolve(__dirname, 'cli.js');
+
+describe('cli doesNotThrow and throws testing', () => {
+  // Correct
+  it('node cli.js', () => {
+    doesNotThrow(() => {
+      execSync(`node ${cli}`); // Expected output: 'no modified files to format'
+    });
+  });
+  it('node cli.js --help', () => {
+    doesNotThrow(() => {
+      execSync(`node ${cli} --help`);
+    });
+  });
+
+  // Wrong
+  it('node cli.js --abcdefg', () => {
+    throws(() => {
+      execSync(`node ${cli} --abcdefg`);
+    });
+  });
+  it('node cli.js --binary=', () => {
+    throws(() => {
+      execSync(`node ${cli} --binary=`);
+    });
+  });
+});

--- a/packages/clang-format-git/src/index.js
+++ b/packages/clang-format-git/src/index.js
@@ -1,0 +1,12 @@
+const {
+  getGitClangFormatPath,
+  getClangFormatGitPath,
+} = require('./utils/getGitClangFormatPath');
+const { gitClangFormatPath, clangFormatGitPath } = require('./utils/gitClangFormatPath');
+
+module.exports = {
+  getGitClangFormatPath,
+  getClangFormatGitPath,
+  gitClangFormatPath,
+  clangFormatGitPath,
+};

--- a/packages/clang-format-git/src/index.test.js
+++ b/packages/clang-format-git/src/index.test.js
@@ -1,0 +1,24 @@
+const { ok } = require('node:assert');
+const { describe, it } = require('node:test');
+
+const {
+  getGitClangFormatPath,
+  getClangFormatGitPath,
+  gitClangFormatPath,
+  clangFormatGitPath,
+} = require('./index');
+
+describe('index ok testing', () => {
+  it('getGitClangFormatPath should be imported correctly', () => {
+    ok(getGitClangFormatPath);
+  });
+  it('getClangFormatGitPath should be imported correctly', () => {
+    ok(getClangFormatGitPath);
+  });
+  it('gitClangFormatPath should be imported correctly', () => {
+    ok(gitClangFormatPath);
+  });
+  it('clangFormatGitPath should be imported correctly', () => {
+    ok(clangFormatGitPath);
+  });
+});

--- a/packages/clang-format-git/src/utils/getGitClangFormatPath.js
+++ b/packages/clang-format-git/src/utils/getGitClangFormatPath.js
@@ -1,0 +1,46 @@
+const { existsSync } = require('fs');
+const { resolve } = require('path');
+
+/**
+ * Returns the ABSOLUTE path to the `git-clang-format` executable binary based on the OS platform and architecture.
+ *
+ * The possible combinations are `darwin-arm64`, `darwin-x64`, `linux-arm`, `linux-arm64`, `linux-ppc64`, `linux-s390x`, `linux-x64`, `win32-x64`.
+ *
+ * Throws an error if the executable is not found.
+ *
+ * @param {string} osPlatform The current operating system platform. (e.g., `darwin`, `linux`, `win32`)
+ * @param {string} architecture The current system architecture. (e.g., `arm`, `arm64`, `ppc64`, `s390x`, `x64`)
+ * @returns {string} The ABSOLUTE path to the `git-clang-format` executable binary.
+ * @throws `Error` Throws an error if the executable binary is not found for the specified OS platform and architecture.
+ * @alias `getClangFormatGitPath`. See {@link getClangFormatGitPath}.
+ * @version `v1.2.0` Initial release.
+ */
+function getGitClangFormatPath(osPlatform, architecture) {
+  const gitClangFormatPath = resolve(
+    __dirname,
+    `..`,
+    `bin`,
+    `cfg-${osPlatform}-${architecture}`,
+    `git-clang-format${osPlatform === 'win32' ? '.exe' : ''}`,
+  );
+
+  if (!existsSync(gitClangFormatPath))
+    throw new Error(
+      `No executable found for '${osPlatform}(OS platform)-${architecture}(architecture)'\nThe possible combinations are 'darwin-arm64', 'darwin-x64', 'linux-arm', 'linux-arm64', 'linux-ppc64', 'linux-s390x', 'linux-x64', 'win32-x64'`,
+    );
+
+  return gitClangFormatPath;
+}
+
+/**
+ * Alias for `getGitClangFormatPath`.
+ *
+ * @alias `getGitClangFormatPath`. See {@link getGitClangFormatPath}.
+ * @version `v1.2.0` Initial release.
+ */
+const getClangFormatGitPath = getGitClangFormatPath;
+
+module.exports = {
+  getGitClangFormatPath,
+  getClangFormatGitPath,
+};

--- a/packages/clang-format-git/src/utils/getGitClangFormatPath.test.js
+++ b/packages/clang-format-git/src/utils/getGitClangFormatPath.test.js
@@ -40,7 +40,7 @@ const allowed = {
   win32: ['x64'],
 };
 
-describe('getClangFormatPath doesNotThrow and throws testing', () => {
+describe('getGitClangFormatPath doesNotThrow and throws testing', () => {
   osPlatforms.forEach(osPlatform => {
     architectures.forEach(architecture => {
       it(`osPlatform: ${osPlatform}, architecture: ${architecture}`, () => {

--- a/packages/clang-format-git/src/utils/getGitClangFormatPath.test.js
+++ b/packages/clang-format-git/src/utils/getGitClangFormatPath.test.js
@@ -1,0 +1,61 @@
+const { doesNotThrow, throws } = require('node:assert');
+const { describe, it } = require('node:test');
+
+const {
+  getGitClangFormatPath,
+  getClangFormatGitPath,
+} = require('./getGitClangFormatPath');
+
+/**
+ * See possible values in {@link https://nodejs.org/api/os.html#osplatform}.
+ */
+const osPlatforms = ['aix', 'darwin', 'freebsd', 'linux', 'openbsd', 'sunos', 'win32'];
+
+/**
+ * See possible values in {@link https://nodejs.org/api/os.html#osarch}.
+ */
+const architectures = [
+  'arm',
+  'arm64',
+  'ia32',
+  'loong64',
+  'mips',
+  'mipsel',
+  'ppc',
+  'ppc64',
+  'riscv64',
+  's390',
+  's390x',
+  'x64',
+];
+
+/**
+ * The possible combinations are `darwin-arm64`, `darwin-x64`, `linux-arm`, `linux-arm64`, `linux-ppc64`, `linux-s390x`, `linux-x64`, `win32-x64`.
+ *
+ * See {@link getClangFormatPath}.
+ */
+const allowed = {
+  darwin: ['arm64', 'x64'],
+  linux: ['arm', 'arm64', 'ppc64', 's390x', 'x64'],
+  win32: ['x64'],
+};
+
+describe('getClangFormatPath doesNotThrow and throws testing', () => {
+  osPlatforms.forEach(osPlatform => {
+    architectures.forEach(architecture => {
+      it(`osPlatform: ${osPlatform}, architecture: ${architecture}`, () => {
+        if (allowed[osPlatform] && allowed[osPlatform].includes(architecture)) {
+          doesNotThrow(() => {
+            getGitClangFormatPath(osPlatform, architecture);
+            getClangFormatGitPath(osPlatform, architecture);
+          });
+        } else {
+          throws(() => {
+            getGitClangFormatPath(osPlatform, architecture);
+            getClangFormatGitPath(osPlatform, architecture);
+          });
+        }
+      });
+    });
+  });
+});

--- a/packages/clang-format-git/src/utils/gitClangFormatPath.js
+++ b/packages/clang-format-git/src/utils/gitClangFormatPath.js
@@ -1,0 +1,24 @@
+const { platform, arch } = require('os');
+
+const { getGitClangFormatPath } = require('./getGitClangFormatPath');
+
+/**
+ * The ABSOLUTE path to the `git-clang-format` executable binary based on the OS platform and architecture.
+ *
+ * @alias `clangFormatGitPath`. See {@link clangFormatGitPath}.
+ * @version `v1.2.0` Initial release.
+ */
+const gitClangFormatPath = getGitClangFormatPath(platform(), arch());
+
+/**
+ * Alias for `gitClangFormatPath`.
+ *
+ * @alias `gitClangFormatPath`. See {@link gitClangFormatPath}.
+ * @version `v1.2.0` Initial release.
+ */
+const clangFormatGitPath = gitClangFormatPath;
+
+module.exports = {
+  gitClangFormatPath,
+  clangFormatGitPath,
+};

--- a/packages/clang-format-git/src/utils/gitClangFormatPath.test.js
+++ b/packages/clang-format-git/src/utils/gitClangFormatPath.test.js
@@ -1,0 +1,15 @@
+const { strictEqual } = require('node:assert');
+const { platform, arch } = require('node:os');
+const { describe, it } = require('node:test');
+
+const { gitClangFormatPath, clangFormatGitPath } = require('./gitClangFormatPath');
+const { getGitClangFormatPath } = require('./getGitClangFormatPath');
+
+describe('gitClangFormatPath strictEqual testing', () => {
+  it('gitClangFormatPath === getGitClangFormatPath(platform(), arch())', () => {
+    strictEqual(gitClangFormatPath, getGitClangFormatPath(platform(), arch()));
+  });
+  it('clangFormatGitPath === gitClangFormatPath', () => {
+    strictEqual(clangFormatGitPath, gitClangFormatPath);
+  });
+});

--- a/packages/clang-format-git/tsconfig.json
+++ b/packages/clang-format-git/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "build"
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]
+}


### PR DESCRIPTION
A new feature has arrived.

`clang-format-git` is now available.

See: https://github.com/lumirlumir/npm-clang-format-node/issues/60