### PR TITLE
release(preminor): v1.2.0-canary.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.1.3"
+  "version": "1.2.0-canary.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15283,11 +15283,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "1.1.3",
+      "version": "1.2.0-canary.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.1.3"
+        "clang-format-node": "^1.2.0-canary.0"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -15298,11 +15298,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "1.1.3",
+      "version": "1.2.0-canary.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.1.3"
+        "clang-format-node": "^1.2.0-canary.0"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -15313,7 +15313,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "1.1.3",
+      "version": "1.2.0-canary.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "1.1.3",
+  "version": "1.2.0-canary.0",
   "description": "Node repackaging of the git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -52,6 +52,6 @@
     "chmod": "find ./src/script ./build/script -type f -exec chmod 755 {} + || true"
   },
   "dependencies": {
-    "clang-format-node": "^1.1.3"
+    "clang-format-node": "^1.2.0-canary.0"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "1.1.3",
+  "version": "1.2.0-canary.0",
   "description": "Node repackaging of the git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -51,6 +51,6 @@
     "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || true"
   },
   "dependencies": {
-    "clang-format-node": "^1.1.3"
+    "clang-format-node": "^1.2.0-canary.0"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "1.1.3",
+  "version": "1.2.0-canary.0",
   "description": "Node repackaging of the clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [


### PR DESCRIPTION
Bump `lumirlumir/npm-clang-format-node` from v1.1.3 to v1.2.0-canary.0 :tada: