### PR TITLE
ci: update `publish.yml` to fix a bug where `publish` script was overwrited

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,6 @@ jobs:
         run: npm run test
 
       - name: Publish
-        run: npm run publish
+        run: npm run publish-package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "scripts": {
     "prepare": "husky",
-    "publish": "npx lerna publish from-package --pre-dist-tag canary --yes",
+    "publish-package": "npx lerna publish from-package --pre-dist-tag canary --yes",
     "build": "npx lerna run build",
     "test": "npx lerna run test",
     "coverage": "npx nyc --reporter=lcov npm run test",


### PR DESCRIPTION
The following error happened.

![image](https://github.com/user-attachments/assets/1fe16a59-6da7-4726-9b3e-65deddbeebf5)
