### PR TITLE
release(patch): v1.2.2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.2.1"
+  "version": "1.2.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17285,11 +17285,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.2.1"
+        "clang-format-node": "^1.2.2"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -17300,11 +17300,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.2.1"
+        "clang-format-node": "^1.2.2"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -17315,7 +17315,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -53,6 +53,6 @@
     "chmod": "find ./src/script ./build/script -type f -exec chmod 755 {} + || true"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.1"
+    "clang-format-node": "^1.2.2"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -52,6 +52,6 @@
     "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || true"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.1"
+    "clang-format-node": "^1.2.2"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [


### PR DESCRIPTION
Bump `lumirlumir/npm-clang-format-node` from v1.2.1 to v1.2.2 :tada: