### PR TITLE
release(patch): v1.2.2

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "scripts": {
     "formatted:c": "npx clang-format src/formatted.c",
     "formatted:c:dry-run": "npx clang-format -Werror -n src/formatted.c",
@@ -12,6 +12,6 @@
     "unformatted:cpp:dry-run": "npx clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.1"
+    "clang-format-node": "^1.2.2"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.2.1"
+  "version": "1.2.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,9 @@
       }
     },
     "examples/clang-format": {
+      "version": "1.2.2",
       "dependencies": {
-        "clang-format-node": "^1.2.1"
+        "clang-format-node": "^1.2.2"
       }
     },
     "examples/git-clang-format": {
@@ -17285,11 +17286,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.2.1"
+        "clang-format-node": "^1.2.2"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -17300,11 +17301,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.2.1"
+        "clang-format-node": "^1.2.2"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -17315,7 +17316,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -17327,17 +17328,19 @@
       }
     },
     "tests/integration-api-cjs": {
+      "version": "1.2.2",
       "dependencies": {
-        "clang-format-git": "^1.2.1",
-        "clang-format-git-python": "^1.2.1",
-        "clang-format-node": "^1.2.1"
+        "clang-format-git": "^1.2.2",
+        "clang-format-git-python": "^1.2.2",
+        "clang-format-node": "^1.2.2"
       }
     },
     "tests/integration-api-esm": {
+      "version": "1.2.2",
       "dependencies": {
-        "clang-format-git": "^1.2.1",
-        "clang-format-git-python": "^1.2.1",
-        "clang-format-node": "^1.2.1"
+        "clang-format-git": "^1.2.2",
+        "clang-format-git-python": "^1.2.2",
+        "clang-format-node": "^1.2.2"
       }
     },
     "tests/integration-binaries-perimission": {
@@ -17349,10 +17352,11 @@
       }
     },
     "tests/integration-binaries-permission": {
+      "version": "1.2.2",
       "dependencies": {
-        "clang-format-git": "^1.2.1",
-        "clang-format-git-python": "^1.2.1",
-        "clang-format-node": "^1.2.1"
+        "clang-format-git": "^1.2.2",
+        "clang-format-git-python": "^1.2.2",
+        "clang-format-node": "^1.2.2"
       }
     },
     "tests/integration-cjs": {

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -53,6 +53,6 @@
     "chmod": "find ./src/script ./build/script -type f -exec chmod 755 {} + || true"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.1"
+    "clang-format-node": "^1.2.2"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -52,6 +52,6 @@
     "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || true"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.1"
+    "clang-format-node": "^1.2.2"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "commonjs",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.1",
-    "clang-format-git-python": "^1.2.1",
-    "clang-format-node": "^1.2.1"
+    "clang-format-git": "^1.2.2",
+    "clang-format-git-python": "^1.2.2",
+    "clang-format-node": "^1.2.2"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.1",
-    "clang-format-git-python": "^1.2.1",
-    "clang-format-node": "^1.2.1"
+    "clang-format-git": "^1.2.2",
+    "clang-format-git-python": "^1.2.2",
+    "clang-format-node": "^1.2.2"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.1",
-    "clang-format-git-python": "^1.2.1",
-    "clang-format-node": "^1.2.1"
+    "clang-format-git": "^1.2.2",
+    "clang-format-git-python": "^1.2.2",
+    "clang-format-node": "^1.2.2"
   }
 }


### PR DESCRIPTION
Bump `lumirlumir/npm-clang-format-node` from v1.2.1 to v1.2.2 :tada: