### PR TITLE
docs: update `CONTRIBUTING.md` with guidelines on using the `node:` namespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,25 @@ All packages are located in the `packages` directory, and the documentation can 
 1. Push them to your remote branch.
 
 1. Submit a pull request.🙇‍♂️
+
+## Others
+
+### `node:` namespace
+
+The `node:` namespace prefix for built-in modules was introduced in Node.js `14.18.0` and `16.0.0`. While using it is recommended for new projects, we use different approaches in this project:
+
+- For regular application code, use standard imports without the `node:` prefix for broader compatibility:
+
+  ```js
+  // Standard import (works in all Node.js versions)
+  const fs = require('fs');
+  ```
+
+- For test files (`.test.js`) that use the `node:test` runner, you may use the `node:` prefix:
+
+  ```js
+  // node: prefix allowed in test files
+  const fs = require('node:fs');
+  ```
+
+This approach helps maintain compatibility across Node.js versions while allowing modern syntax in test environments where version constraints are less critical.


### PR DESCRIPTION
This pull request includes an update to the `CONTRIBUTING.md` file to provide guidance on the usage of the `node:` namespace prefix for built-in modules in Node.js. The most important change is the addition of a new section explaining the recommended usage patterns for different parts of the project.

Documentation updates:

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R48-R69): Added a new section titled "Others" with a subsection on the `node:` namespace. It explains that standard imports without the `node:` prefix should be used for regular application code for broader compatibility, while the `node:` prefix can be used in test files that use the `node:test` runner.