### PR TITLE
chore: ready for introduction of website using `nextra`

### DIFF
--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -39,7 +39,7 @@ lumirlumir/lumirlumir-configs:
     dest: ./configs/.husky/pre-commit
   # ./.vscode
   - source: ./.vscode/extensions.json
-    dest: ./configs/.vscode/npm-extensions.json
+    dest: ./configs/.vscode/web-extensions.json
   - source: ./.vscode/settings.json
     dest: ./configs/.vscode/settings.json
   # ./

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
+    "stylelint.vscode-stylelint",
     "esbenp.prettier-vscode",
     "editorconfig.editorconfig",
     "davidanson.vscode-markdownlint"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "workspaces": [
         "examples/*",
         "packages/*",
-        "tests/*"
+        "tests/*",
+        "website"
       ],
       "devDependencies": {
         "@babel/cli": "^7.24.8",
@@ -16765,6 +16766,10 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/website": {
+      "resolved": "website",
+      "link": true
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -17396,6 +17401,9 @@
         "clang-format-git-python": "^1.2.1",
         "clang-format-node": "^1.2.1"
       }
+    },
+    "website": {
+      "version": "1.2.2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "workspaces": [
     "examples/*",
     "packages/*",
-    "tests/*"
+    "tests/*",
+    "website"
   ],
   "scripts": {
     "prepare": "husky",

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "website",
+  "version": "1.2.2",
+  "scripts": {
+    "start": "echo start"
+  }
+}


### PR DESCRIPTION
This pull request includes several important changes to the configuration files and the project structure. The most significant changes involve updates to the `.vscode` settings, the addition of a new workspace, and the creation of a `package.json` for the `website` directory.

Updates to `.vscode` settings:

* [`.github/sync-client.yml`](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1L42-R42): Changed the destination of the `.vscode/extensions.json` file from `npm-extensions.json` to `web-extensions.json`.
* [`.vscode/extensions.json`](diffhunk://#diff-c16655a98a3ee89a7636a59c59a72b0e93649e3a1e947327cfc43a1336b4e912R4): Added `stylelint.vscode-stylelint` to the list of recommended extensions.

Project structure changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6-R7): Added `website` to the list of workspaces.
* [`website/package.json`](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76R1-R8): Created a new `package.json` file for the `website` directory with basic configuration, including a `start` script.