### PR TITLE
chore: bump macOS version references to `13` in CI workflow and documentation

### DIFF
--- a/.github/workflows/llvm-build-bump-pr.yml
+++ b/.github/workflows/llvm-build-bump-pr.yml
@@ -246,7 +246,7 @@ jobs:
       matrix:
         type:
           - macos-14 # arm64 (macos-latest: arm64)
-          - macos-12 # x64 (macos-13: x64)
+          - macos-13 # x64 (macos-12(deprecated): x64)
 
     # Use the oldest version possible for backward compatibility.
     runs-on: ${{ matrix.type }}

--- a/docs/01-introduction/05-supported.md
+++ b/docs/01-introduction/05-supported.md
@@ -51,7 +51,6 @@ macOS 14                     | `macos-latest-large` or `macos-14-large`         
 macOS 14 Arm64               | `macos-latest`, `macos-14`, `macos-latest-xlarge` or `macos-14-xlarge` | macOS-14-arm64    |
 macOS 13                     | `macos-13` or `macos-13-large`                                         | macOS-13          |
 macOS 13 Arm64               | `macos-13-xlarge`                                                      | macOS-13-arm64    |
-macOS 12                     | `macos-12` or `macos-12-large`                                         | macOS-12          |
 Ubuntu 24.04                 | `ubuntu-latest` or `ubuntu-24.04`                                      | ubuntu-24.04      |
 Ubuntu 22.04                 | `ubuntu-22.04`                                                         | ubuntu-22.04      |
 Windows Server 2022          | `windows-latest` or `windows-2022`                                     | windows-2022      |
@@ -74,7 +73,7 @@ We used the following Images to build `clang-format` excuatable binaries.
 Binary Folder Name | Docker(Build) Image                                                |
 ------------------ | ------------------------------------------------------------------ |
 `darwin-arm64`     | GitHub Actions runner `macos-14`                                   |
-`darwin-x64`       | GitHub Actions runner `macos-12`                                   |
+`darwin-x64`       | GitHub Actions runner `macos-13`                                   |
 `linux-arm`        | [`arm32v7/ubuntu:22.04`](https://hub.docker.com/r/arm32v7/ubuntu/) |
 `linux-arm64`      | [`arm64v8/ubuntu:22.04`](https://hub.docker.com/r/arm64v8/ubuntu/) |
 `linux-ppc64`      | [`ppc64le/ubuntu:22.04`](https://hub.docker.com/r/ppc64le/ubuntu/) |


### PR DESCRIPTION
This pull request includes updates to the macOS versions used in the GitHub Actions workflows and the corresponding documentation. The most important changes include updating the macOS version from 12 to 13 and ensuring the documentation reflects these changes.

Updates to macOS versions:

* [`.github/workflows/llvm-build-bump-pr.yml`](diffhunk://#diff-d608eb75b383338d789a8908995e47499214a7cc55a847771ad73800464b18b0L249-R249): Changed the macOS version from 12 to 13 for x64 architecture in the matrix configuration.

Documentation updates:

* [`docs/01-introduction/05-supported.md`](diffhunk://#diff-664f5e525371f1677c342e11b06a53a625232a2dad8f12bbde8eeab27e037b09L54): Removed references to macOS 12 and updated them to macOS 13 in the supported platforms list.
* [`docs/01-introduction/05-supported.md`](diffhunk://#diff-664f5e525371f1677c342e11b06a53a625232a2dad8f12bbde8eeab27e037b09L77-R76): Updated the binary folder name table to reflect the change from macOS 12 to macOS 13 for `darwin-x64`.