### PR TITLE
release(patch): v1.2.3

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-clang-format",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "scripts": {
     "formatted:c": "npx clang-format src/formatted.c",
     "formatted:c:dry-run": "npx clang-format -Werror -n src/formatted.c",
@@ -13,6 +13,6 @@
     "unformatted:cpp:dry-run": "npx clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.2"
+    "clang-format-node": "^1.2.3"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.2.2"
+  "version": "1.2.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,9 @@
     },
     "examples/clang-format": {
       "name": "examples-clang-format",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
-        "clang-format-node": "^1.2.2"
+        "clang-format-node": "^1.2.3"
       }
     },
     "examples/git-clang-format": {
@@ -16527,11 +16527,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.2.2"
+        "clang-format-node": "^1.2.3"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -16542,11 +16542,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.2.2"
+        "clang-format-node": "^1.2.3"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -16557,7 +16557,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -16570,20 +16570,20 @@
     },
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
-        "clang-format-git": "^1.2.2",
-        "clang-format-git-python": "^1.2.2",
-        "clang-format-node": "^1.2.2"
+        "clang-format-git": "^1.2.3",
+        "clang-format-git-python": "^1.2.3",
+        "clang-format-node": "^1.2.3"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
-        "clang-format-git": "^1.2.2",
-        "clang-format-git-python": "^1.2.2",
-        "clang-format-node": "^1.2.2"
+        "clang-format-git": "^1.2.3",
+        "clang-format-git-python": "^1.2.3",
+        "clang-format-node": "^1.2.3"
       }
     },
     "tests/integration-binaries-perimission": {
@@ -16596,11 +16596,11 @@
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
-        "clang-format-git": "^1.2.2",
-        "clang-format-git-python": "^1.2.2",
-        "clang-format-node": "^1.2.2"
+        "clang-format-git": "^1.2.3",
+        "clang-format-git-python": "^1.2.3",
+        "clang-format-node": "^1.2.3"
       }
     },
     "tests/integration-cjs": {
@@ -16636,7 +16636,7 @@
       }
     },
     "website": {
-      "version": "1.2.2"
+      "version": "1.2.3"
     }
   }
 }

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -53,6 +53,6 @@
     "chmod": "find ./src/script ./build/script -type f -exec chmod 755 {} + || true"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.2"
+    "clang-format-node": "^1.2.3"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -52,6 +52,6 @@
     "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || true"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.2"
+    "clang-format-node": "^1.2.3"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-cjs",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "commonjs",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.2",
-    "clang-format-git-python": "^1.2.2",
-    "clang-format-node": "^1.2.2"
+    "clang-format-git": "^1.2.3",
+    "clang-format-git-python": "^1.2.3",
+    "clang-format-node": "^1.2.3"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-esm",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.2",
-    "clang-format-git-python": "^1.2.2",
-    "clang-format-node": "^1.2.2"
+    "clang-format-git": "^1.2.3",
+    "clang-format-git-python": "^1.2.3",
+    "clang-format-node": "^1.2.3"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "tests-integration-binaries-permission",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.2",
-    "clang-format-git-python": "^1.2.2",
-    "clang-format-node": "^1.2.2"
+    "clang-format-git": "^1.2.3",
+    "clang-format-git-python": "^1.2.3",
+    "clang-format-node": "^1.2.3"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "scripts": {
     "start": "echo start"
   }


### PR DESCRIPTION
Bump `lumirlumir/npm-clang-format-node` from v1.2.2 to v1.2.3 :tada: