### PR TITLE
docs: update `README.md` of `examples-clang-format`

### DIFF
--- a/examples/clang-format/README.md
+++ b/examples/clang-format/README.md
@@ -1,23 +1,55 @@
-# `clang-format` Example
+# `examples-clang-format`
 
-This `clang-format` example is provided to showcase the features included in `clang-format`.
+This example demonstrates the features included in `clang-format`.
 
 To see which commands are available, check the `scripts` property in `package.json`.
 
-## Running a Command
+## Getting Started
 
-For example, to run the `unformatted:cpp:dry-run` command:
+You can run the example by choosing one of the following two methods.
 
-- From the root directory (`/`)
+### Run from the Root
 
-    ```bash
-    npm run unformatted:cpp:dry-run -w examples/clang-format
-    ```
+You can start the example by running the following commands from the root directory:
 
-- From the `examples/clang-format` directory (`/examples/clang-format`)
+```sh
+npm run formatted:c -w examples/clang-format
+# or
+npm run formatted:c:dry-run -w examples/clang-format
+# or
+npm run formatted:cpp -w examples/clang-format
+# or
+npm run formatted:cpp:dry-run -w examples/clang-format
+# or
+npm run unformatted:c -w examples/clang-format
+# or
+npm run unformatted:c:dry-run -w examples/clang-format
+# or
+npm run unformatted:cpp -w examples/clang-format
+# or
+npm run unformatted:cpp:dry-run -w examples/clang-format
+```
 
-    ```bash
-    cd examples/clang-format
+### Navigate to the Directory and Run
 
-    npm run unformatted:cpp:dry-run
-    ```
+Navigate to the `examples/clang-format` directory and then run the following commands to start the example:
+
+```sh
+cd examples/clang-format
+
+npm run formatted:c
+# or
+npm run formatted:c:dry-run
+# or
+npm run formatted:cpp
+# or
+npm run formatted:cpp:dry-run
+# or
+npm run unformatted:c
+# or
+npm run unformatted:c:dry-run
+# or
+npm run unformatted:cpp
+# or
+npm run unformatted:cpp:dry-run
+```


### PR DESCRIPTION
This pull request includes updates to the `examples/clang-format/README.md` file to improve clarity and provide more comprehensive instructions for running the example. The most important changes include renaming the example, restructuring the instructions, and expanding the list of commands.

Improvements to documentation:

* Renamed the example from `clang-format` to `examples-clang-format` for consistency.
* Restructured the instructions by adding a "Getting Started" section and separating the methods for running the example into "Run from the Root" and "Navigate to the Directory and Run" sections.
* Expanded the list of available commands to include all variations of formatted and unformatted commands for both C and C++ languages.