### PR TITLE
fix: Windows support-`exit 0` instead of `true` in scripts

### DIFF
--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -50,7 +50,7 @@
     "build": "npx babel src -d build && npx tsc && cp -r src/script build && cp ../../LICENSE.md ../../README.md .",
     "postbuild": "npm run chmod",
     "test": "node --test",
-    "chmod": "find ./src/script ./build/script -type f -exec chmod 755 {} + || true"
+    "chmod": "find ./src/script ./build/script -type f -exec chmod 755 {} + || exit 0"
   },
   "dependencies": {
     "clang-format-node": "^1.2.3"

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -49,7 +49,7 @@
     "build": "npx babel src -d build && npx tsc && cp -r src/bin build && cp ../../LICENSE.md ../../README.md .",
     "postbuild": "npm run chmod",
     "test": "node --test",
-    "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || true"
+    "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || exit 0"
   },
   "dependencies": {
     "clang-format-node": "^1.2.3"

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -48,6 +48,6 @@
     "build": "npx babel src -d build && npx tsc && cp -r src/bin build && cp ../../LICENSE.md ../../README.md .",
     "postbuild": "npm run chmod",
     "test": "node --test",
-    "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || true"
+    "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || exit 0"
   }
 }


### PR DESCRIPTION
# Support running `git-clang-format` on windows machines.

## Summary

I am using [Angular clang-format](https://www.npmjs.com/package/clang-format) for formatting my C++ code used to build Node.js Native Addon. I want to support arm64 targets, and Angular clang-format only supports amd64 ones. I wanted to adopt `git-clang-format` in place of it as it bundles linux-arm64 and darwin-arm64 binaries (but not windows-arm64 which would also be highly appreciated).

I tried the following:
1. Add `clang-format-git` as dev dependency
2. Run `npm i` on windows machine

And got an error:
```
npm error command C:\WINDOWS\system32\cmd.exe /d /s /c test -d src && npm run build || npm run chmod
npm error > clang-format-git@1.2.3 chmod
npm error > find ./src/bin ./build/bin -type f -exec chmod 755 {} + || true
npm error 'test' is not recognized as an internal or external command,
npm error operable program or batch file.
npm error FIND: Parameter format not correct
npm error 'true' is not recognized as an internal or external command,
npm error operable program or batch file.
```

## Details

The error originates from `postinstall` scripts, mainly from tail command `|| true`. The error reproduces in both CMD and PowerShell. Current `postinstall` script runs successfully only in git-bash and WSL. But in my case I have to run `npm i` from Visual Studio Developer Console which is either CMD or PowerShell.

To fix the error `|| exit 0` could be used in place of `|| true` as a windows-compatible alternative.

BTW I would highly appreciate if new version would be published to the npm registry after this change is merged, so I would be able to use this package :)

## How did you test this change?

After the change I was able to successfully use package both from PowerShell and WSL.

## Resolved Issues

Closes #170
