### PR TITLE
chore: add `engines` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "private": true,
   "packageManager": "npm@10.9.2",
+  "engines": {
+    "node": ">=20.18.0"
+  },
   "workspaces": [
     "examples/*",
     "packages/*",


### PR DESCRIPTION
This pull request includes a change to the `package.json` file to specify the required Node.js version for the project.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R4-R6): Added an `engines` field to specify that the project requires Node.js version 20.18.0 or higher.