### PR TITLE
release(patch): v1.2.5

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-clang-format",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "scripts": {
     "formatted:c": "npx clang-format src/formatted.c",
     "formatted:c:dry-run": "npx clang-format -Werror -n src/formatted.c",
@@ -13,6 +13,6 @@
     "unformatted:cpp:dry-run": "npx clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.4"
+    "clang-format-node": "^1.2.5"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-git-clang-format",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "scripts": {
     "add-a-space-to-line-9-of-main-c-file": "cat src/main_overwrite.txt > src/main.c",
     "git-add": "git add src/main.c && git status",
     "git-clang-format": "npx git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.4"
+    "clang-format-git": "^1.2.5"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.2.4"
+  "version": "1.2.5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,16 +35,16 @@
     },
     "examples/clang-format": {
       "name": "examples-clang-format",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
-        "clang-format-node": "^1.2.4"
+        "clang-format-node": "^1.2.5"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
-        "clang-format-git": "^1.2.4"
+        "clang-format-git": "^1.2.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -16720,11 +16720,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "1.2.4",
+      "version": "1.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.2.4"
+        "clang-format-node": "^1.2.5"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -16735,11 +16735,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "1.2.4",
+      "version": "1.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.2.4"
+        "clang-format-node": "^1.2.5"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -16750,7 +16750,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "1.2.4",
+      "version": "1.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -16763,20 +16763,20 @@
     },
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
-        "clang-format-git": "^1.2.4",
-        "clang-format-git-python": "^1.2.4",
-        "clang-format-node": "^1.2.4"
+        "clang-format-git": "^1.2.5",
+        "clang-format-git-python": "^1.2.5",
+        "clang-format-node": "^1.2.5"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
-        "clang-format-git": "^1.2.4",
-        "clang-format-git-python": "^1.2.4",
-        "clang-format-node": "^1.2.4"
+        "clang-format-git": "^1.2.5",
+        "clang-format-git-python": "^1.2.5",
+        "clang-format-node": "^1.2.5"
       }
     },
     "tests/integration-binaries-perimission": {
@@ -16789,11 +16789,11 @@
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
-        "clang-format-git": "^1.2.4",
-        "clang-format-git-python": "^1.2.4",
-        "clang-format-node": "^1.2.4"
+        "clang-format-git": "^1.2.5",
+        "clang-format-git-python": "^1.2.5",
+        "clang-format-node": "^1.2.5"
       }
     },
     "tests/integration-cjs": {
@@ -16829,7 +16829,7 @@
       }
     },
     "website": {
-      "version": "1.2.4"
+      "version": "1.2.5"
     }
   }
 }

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -53,6 +53,6 @@
     "chmod": "find ./src/script ./build/script -type f -exec chmod 755 {} + || exit 0"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.4"
+    "clang-format-node": "^1.2.5"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -52,6 +52,6 @@
     "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || exit 0"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.4"
+    "clang-format-node": "^1.2.5"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-cjs",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "type": "commonjs",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.4",
-    "clang-format-git-python": "^1.2.4",
-    "clang-format-node": "^1.2.4"
+    "clang-format-git": "^1.2.5",
+    "clang-format-git-python": "^1.2.5",
+    "clang-format-node": "^1.2.5"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-esm",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.4",
-    "clang-format-git-python": "^1.2.4",
-    "clang-format-node": "^1.2.4"
+    "clang-format-git": "^1.2.5",
+    "clang-format-git-python": "^1.2.5",
+    "clang-format-node": "^1.2.5"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "tests-integration-binaries-permission",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.4",
-    "clang-format-git-python": "^1.2.4",
-    "clang-format-node": "^1.2.4"
+    "clang-format-git": "^1.2.5",
+    "clang-format-git-python": "^1.2.5",
+    "clang-format-node": "^1.2.5"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "scripts": {
     "start": "echo start"
   }


### PR DESCRIPTION
Bump `lumirlumir/npm-clang-format-node` from v1.2.4 to v1.2.5 :tada: