### PR TITLE
docs: fix incorrect comment placement

### DIFF
--- a/packages/clang-format-node/src/cli.js
+++ b/packages/clang-format-node/src/cli.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 // The shebang line `#!/usr/bin/env node` ensures the script runs with the correct Node.js interpreter across different environments.
 
-/* eslint-disable n/prefer-node-protocol */
-
 /**
  * @fileoverview Entry file for the `npx clang-format` and `npx clang-format-node` command. See the `bin` property in `package.json`.
  */
+
+/* eslint-disable n/prefer-node-protocol */
 
 // --------------------------------------------------------------------------------
 // Require


### PR DESCRIPTION
This pull request includes a minor change to the `packages/clang-format-node/src/cli.js` file. The change repositions the ESLint directive `/* eslint-disable n/prefer-node-protocol */` to a different location within the file for better code organization.

* [`packages/clang-format-node/src/cli.js`](diffhunk://#diff-10e5439e75c8ce1bc7c2f61004997244cb90676b01d19b66ac9f3ba7a6b2fb67L4-R9): Moved the ESLint directive `/* eslint-disable n/prefer-node-protocol */` to a location after the file overview comment.