### PR TITLE
docs: update eslint-disable comments for backward compatibility with `node:` namespace

### DIFF
--- a/packages/clang-format-git-python/src/cli.js
+++ b/packages/clang-format-git-python/src/cli.js
@@ -4,7 +4,7 @@
  * @fileoverview Entry file for the `npx git-clang-format` or `npx clang-format-git-python` command. See the `bin` property in `package.json`.
  */
 
-/* eslint-disable n/prefer-node-protocol */
+/* eslint-disable n/prefer-node-protocol -- DO NOT USE `node:` namespace for backward compatibility */
 
 // --------------------------------------------------------------------------------
 // Require

--- a/packages/clang-format-git-python/src/utils/gitClangFormatPath.js
+++ b/packages/clang-format-git-python/src/utils/gitClangFormatPath.js
@@ -2,7 +2,7 @@
  * @fileoverview `gitClangFormatPath` and `clangFormatGitPythonPath` APIs.
  */
 
-/* eslint-disable n/prefer-node-protocol */
+/* eslint-disable n/prefer-node-protocol -- DO NOT USE `node:` namespace for backward compatibility */
 
 // --------------------------------------------------------------------------------
 // Require

--- a/packages/clang-format-git/src/cli.js
+++ b/packages/clang-format-git/src/cli.js
@@ -4,7 +4,7 @@
  * @fileoverview Entry file for the `npx git-clang-format` or `npx clang-format-git` command. See the `bin` property in `package.json`.
  */
 
-/* eslint-disable n/prefer-node-protocol */
+/* eslint-disable n/prefer-node-protocol -- DO NOT USE `node:` namespace for backward compatibility */
 
 // --------------------------------------------------------------------------------
 // Require

--- a/packages/clang-format-git/src/utils/getGitClangFormatPath.js
+++ b/packages/clang-format-git/src/utils/getGitClangFormatPath.js
@@ -2,7 +2,7 @@
  * @fileoverview `getGitClangFormatPath` and `getClangFormatGitPath` APIs.
  */
 
-/* eslint-disable n/prefer-node-protocol */
+/* eslint-disable n/prefer-node-protocol -- DO NOT USE `node:` namespace for backward compatibility */
 
 // --------------------------------------------------------------------------------
 // Require

--- a/packages/clang-format-git/src/utils/gitClangFormatPath.js
+++ b/packages/clang-format-git/src/utils/gitClangFormatPath.js
@@ -2,7 +2,7 @@
  * @fileoverview `gitClangFormatPath` and `clangFormatGitPath` APIs.
  */
 
-/* eslint-disable n/prefer-node-protocol */
+/* eslint-disable n/prefer-node-protocol -- DO NOT USE `node:` namespace for backward compatibility */
 
 // --------------------------------------------------------------------------------
 // Require

--- a/packages/clang-format-node/src/cli.js
+++ b/packages/clang-format-node/src/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // The shebang line `#!/usr/bin/env node` ensures the script runs with the correct Node.js interpreter across different environments.
 
-/* eslint-disable n/prefer-node-protocol */
+/* eslint-disable n/prefer-node-protocol -- DO NOT USE `node:` namespace for backward compatibility */
 
 /**
  * @fileoverview Entry file for the `npx clang-format` and `npx clang-format-node` command. See the `bin` property in `package.json`.

--- a/packages/clang-format-node/src/utils/clangFormatPath.js
+++ b/packages/clang-format-node/src/utils/clangFormatPath.js
@@ -2,7 +2,7 @@
  * @fileoverview `clangFormatPath` and `clangFormatNodePath` APIs.
  */
 
-/* eslint-disable n/prefer-node-protocol */
+/* eslint-disable n/prefer-node-protocol -- DO NOT USE `node:` namespace for backward compatibility */
 
 // --------------------------------------------------------------------------------
 // Require

--- a/packages/clang-format-node/src/utils/getClangFormatPath.js
+++ b/packages/clang-format-node/src/utils/getClangFormatPath.js
@@ -2,7 +2,7 @@
  * @fileoverview `getClangFormatPath` and `getClangFormatNodePath` APIs.
  */
 
-/* eslint-disable n/prefer-node-protocol */
+/* eslint-disable n/prefer-node-protocol -- DO NOT USE `node:` namespace for backward compatibility */
 
 // --------------------------------------------------------------------------------
 // Require


### PR DESCRIPTION
This pull request includes several changes across multiple files to ensure backward compatibility by not using the `node:` namespace. The changes are consistent across different files and packages.

Backward compatibility:

* [`packages/clang-format-git-python/src/cli.js`](diffhunk://#diff-93f1a01c7f4ac5a2380112cca516851320758c8184f96cddb10e1cc97012a468L7-R7): Updated eslint-disable comment to specify not using `node:` namespace for backward compatibility.
* [`packages/clang-format-git-python/src/utils/gitClangFormatPath.js`](diffhunk://#diff-0b92886b850ec05cf8174fb293fc1d7f26dfd6064e907bfc81e09da43c8e1e49L5-R5): Updated eslint-disable comment to specify not using `node:` namespace for backward compatibility.
* [`packages/clang-format-git/src/cli.js`](diffhunk://#diff-63ba214e13f2c5ab6dd124bf509fd488f9e2c9480f2db2c0e8293f0f38887bd7L7-R7): Updated eslint-disable comment to specify not using `node:` namespace for backward compatibility.
* [`packages/clang-format-git/src/utils/getGitClangFormatPath.js`](diffhunk://#diff-1bb2e643c38d95e89f5956f9701352544d048ce9b211521186d0aecda6a2b09bL5-R5): Updated eslint-disable comment to specify not using `node:` namespace for backward compatibility.
* [`packages/clang-format-git/src/utils/gitClangFormatPath.js`](diffhunk://#diff-1adcc2abfa385d5db149f797a576817728d4ddee81c1b9196d60ce4d8328390eL5-R5): Updated eslint-disable comment to specify not using `node:` namespace for backward compatibility.
* [`packages/clang-format-node/src/cli.js`](diffhunk://#diff-10e5439e75c8ce1bc7c2f61004997244cb90676b01d19b66ac9f3ba7a6b2fb67L8-R8): Updated eslint-disable comment to specify not using `node:` namespace for backward compatibility.
* [`packages/clang-format-node/src/utils/clangFormatPath.js`](diffhunk://#diff-2fec3a5daf6d86f193c4f1bf1b809829a7471077b651f5233947089305a1371fL5-R5): Updated eslint-disable comment to specify not using `node:` namespace for backward compatibility.
* [`packages/clang-format-node/src/utils/getClangFormatPath.js`](diffhunk://#diff-69431841c8379c19bac868db91bce476be6122cca550dd2bb841a8fd7d050ebbL5-R5): Updated eslint-disable comment to specify not using `node:` namespace for backward compatibility.