### PR TITLE
ci: update labeler workflow to trigger on edited pull requests

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,7 +2,7 @@ name: labeler
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, edited]
 
 jobs:
   labeler:
@@ -10,6 +10,7 @@ jobs:
 
     steps:
       - name: Labeler
+        if: github.event.action == 'opened' || github.event.changes.title
         uses: jimschubert/labeler-action@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow for labeling pull requests. The change ensures that the labeler action runs not only when a pull request is opened but also when it is edited.

* [`.github/workflows/labeler.yml`](diffhunk://#diff-09b72f3c9a3e4f00ab00cd7000b302db25f056075d8895bd91b3654d6e7e956bL5-R13): Modified the `pull_request_target` event to include the `edited` type and added a condition to run the labeler step when the pull request is opened or its title is changed.