### PR TITLE
refactor(website): add Google Analytics integration to `.vitepress/config.mjs`

### DIFF
--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -25,6 +25,7 @@ const AUTHOR = '루밀LuMir';
 const SITE_URL = 'https://clang-format-node.lumir.page';
 const GITHUB_URL = 'https://github.com/lumirlumir/npm-clang-format-node';
 const NPM_URL = 'https://www.npmjs.com';
+const GOOGLE_GA_ID = 'G-SVZGJNXDB2';
 
 // --------------------------------------------------------------------------------
 // Export
@@ -67,12 +68,21 @@ export default defineConfig({
     ['meta', { name: 'twitter:creator', content: AUTHOR }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
 
-    // TODO: Add @vercel/speed-insight
-    // TODO: Add @vercel/analytics
+    // Google Analytics
+    [
+      'script',
+      { async: '', src: `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_GA_ID}` },
+    ],
+    [
+      'script',
+      {},
+      `window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '${GOOGLE_GA_ID}');`,
+    ],
   ],
   lang: 'en-US',
-
-  // TODO: stylelint?
 
   /* Routing */
   cleanUrls: true,

--- a/website/docs/get-started/configuration.md
+++ b/website/docs/get-started/configuration.md
@@ -56,7 +56,7 @@ my-monorepo/
 >
 > To see the full list of options, check the [Clang-Format Style Options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) page.
 
-You can use the `.clang-format` file to configure the style of your code. Here is an brief example of a `.clang-format` file:
+You can use the `.clang-format` file to configure the style of your code. Here is a brief example of a `.clang-format` file:
 
 - Simple:
 


### PR DESCRIPTION
This pull request includes changes to add Google Analytics to the website configuration and a minor documentation correction. The most important changes include adding the Google Analytics ID and script to the configuration file and fixing a typo in the documentation.

### Configuration updates:

* [`website/.vitepress/config.mjs`](diffhunk://#diff-bd4ac01d4c35583e9c20414103304b0628a6be199987bd1084fdef61cd43cc71R28): Added `GOOGLE_GA_ID` constant and included Google Analytics script tags for tracking. [[1]](diffhunk://#diff-bd4ac01d4c35583e9c20414103304b0628a6be199987bd1084fdef61cd43cc71R28) [[2]](diffhunk://#diff-bd4ac01d4c35583e9c20414103304b0628a6be199987bd1084fdef61cd43cc71L70-L76)

### Documentation correction:

* [`website/docs/get-started/configuration.md`](diffhunk://#diff-6a87b005e020bd2dfcf1e779a14c7ddc13bfc307a99b1b02b6c538e7f4da1b77L59-R59): Corrected a typo from "an brief example" to "a brief example".