### PR TITLE
docs: create `q-and-a.md`

### DIFF
--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -206,6 +206,10 @@ export default defineConfig({
               text: 'Use with <code>husky</code>, <code>lint-staged</code>',
               link: 'use-with-husky-and-lint-staged',
             },
+            {
+              text: 'Q & A',
+              link: 'q-and-a',
+            },
           ],
         },
 

--- a/website/docs/get-started/q-and-a.md
+++ b/website/docs/get-started/q-and-a.md
@@ -1,0 +1,16 @@
+---
+description: Questions and answers about clang-format-node.
+---
+
+# Q & A
+
+## Why are the results of `clang-format` and `git-clang-format` different?
+
+> [!NOTE] References
+>
+> - [Why are the results of `clang-format` and `git-clang-format` different?](https://stackoverflow.com/questions/76968316/why-are-the-results-of-clang-format-and-git-clang-format-different) on Stack Overflow.
+> - [Git Intergration](https://clang.llvm.org/docs/ClangFormat.html#git-integration) on LLVM Clang.
+
+`git-clang-format` only formats changes. `clang-format` formats the whole document.
+
+The script [`clang/tools/clang-format/git-clang-format`](https://github.com/llvm/llvm-project/blob/main/clang/tools/clang-format/git-clang-format) can be used to format just the lines touched in git commits.


### PR DESCRIPTION
This pull request adds a new "Q & A" section to the documentation and updates the website configuration to include a link to this new section.

Documentation updates:

* Added a new "Q & A" section to the documentation with questions and answers about `clang-format-node`, including an explanation of the differences between `clang-format` and `git-clang-format`. (`website/docs/get-started/q-and-a.md`)

Website configuration updates:

* Updated the VitePress configuration to include a link to the new "Q & A" section in the navigation menu. (`website/.vitepress/config.mjs`)