### PR TITLE
docs: add navigation link to 'Why We Started This Project' in `get-started /index.md` documentation

### DIFF
--- a/website/docs/get-started/index.md
+++ b/website/docs/get-started/index.md
@@ -1,5 +1,8 @@
 ---
 description: "Documentation and details for the `clang-format-node` package, including included packages, support, contributing guidelines, and more."
+next:
+  text: 'Why We Started This Project'
+  link: '/docs/get-started/why-we-started-this-project/'
 ---
 
 <!-- @include: ../../../README.md -->


### PR DESCRIPTION
This pull request includes an update to the `website/docs/get-started/index.md` file to enhance the navigation within the documentation. The most important change is the addition of a link to provide context on why the project was started.

Documentation enhancement:

* [`website/docs/get-started/index.md`](diffhunk://#diff-5c932f6df78484172c717421fffc4ef01f10355cd96ebd8b86b65e02b39f99b3R3-R5): Added a "Next" section with a link to 'Why We Started This Project' to improve navigation and provide additional context for users.