### PR TITLE
ci: update commit type of `llvm-build-bump-pr.yml` to `chore` from `build`

### DIFF
--- a/.github/workflows/llvm-build-bump-pr.yml
+++ b/.github/workflows/llvm-build-bump-pr.yml
@@ -426,10 +426,10 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GH_PAT }}
-          commit-message: 'build(deps): bump LLVM from ${{ needs.stage1.outputs.LLVM_CURRENT_RELEASE_TAG_NAME }} to ${{ needs.stage1.outputs.LLVM_LATEST_RELEASE_TAG_NAME }}'
+          commit-message: 'chore(deps): bump LLVM from ${{ needs.stage1.outputs.LLVM_CURRENT_RELEASE_TAG_NAME }} to ${{ needs.stage1.outputs.LLVM_LATEST_RELEASE_TAG_NAME }}'
           branch: 'bump-llvm-from-${{ needs.stage1.outputs.LLVM_CURRENT_RELEASE_TAG_NAME }}-to-${{ needs.stage1.outputs.LLVM_LATEST_RELEASE_TAG_NAME }}'
           base: 'main'
-          title: 'build(deps): bump LLVM from ${{ needs.stage1.outputs.LLVM_CURRENT_RELEASE_TAG_NAME }} to ${{ needs.stage1.outputs.LLVM_LATEST_RELEASE_TAG_NAME }}'
+          title: 'chore(deps): bump LLVM from ${{ needs.stage1.outputs.LLVM_CURRENT_RELEASE_TAG_NAME }} to ${{ needs.stage1.outputs.LLVM_LATEST_RELEASE_TAG_NAME }}'
           body: |
             This PR bumps the LLVM version from `${{ needs.stage1.outputs.LLVM_CURRENT_RELEASE_TAG_NAME }}` to `${{ needs.stage1.outputs.LLVM_LATEST_RELEASE_TAG_NAME }}` using LLVM binary that was built automatically. :tada:
 

--- a/website/docs/get-started/introduction.md
+++ b/website/docs/get-started/introduction.md
@@ -140,7 +140,7 @@ Here’s an example:
         modified:   x.cpp
     ```
 
-1. `git diff` will show the unstaged changes – the changes created by `clang-format`.
+1. `git diff` will show the unstaged changes – the changes created by `clang-format`:
 
     ```sh
     $ git diff


### PR DESCRIPTION
This pull request includes changes to update the commit message and title format in the LLVM bump workflow and a minor documentation update.

Changes to workflow:

* [`.github/workflows/llvm-build-bump-pr.yml`](diffhunk://#diff-d608eb75b383338d789a8908995e47499214a7cc55a847771ad73800464b18b0L429-R432): Updated the commit message and title prefix from 'build(deps)' to 'chore(deps)' for consistency with other dependency updates.

Documentation update:

* [`website/docs/get-started/introduction.md`](diffhunk://#diff-aeb0fea669d0b87f99bf331106ddc13e198f254aa732266a2435acf9a98f82aaL143-R143): Added a colon at the end of the sentence to clarify the explanation of the `git diff` command output.