### PR TITLE
ci: add PowerShell and CMD test to `test-cross-platform.yml`

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -122,11 +122,7 @@ jobs:
       - name: Windows CMD test
         if: runner.os == 'Windows'
         shell: cmd
-        run: |
-          npx clang-format-node --help
-          npx clang-format-node --version
-          npx clang-format-git --help
-          npx clang-format-git-python --help
+        run: npx clang-format-node --help && npx clang-format-node --version && npx clang-format-git --help && npx clang-format-git-python --help
 
   docker-images:
     strategy:

--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -103,16 +103,30 @@ jobs:
           Get-ChildItem -Recurse -Filter "clang-format-node-*.tgz" | ForEach-Object { npm install $_.FullName }
           Get-ChildItem -Recurse -Filter "clang-format-git-*.tgz" | ForEach-Object { npm install $_.FullName }
 
-      - name: Test clang-format-git
-        run: npx clang-format-git --help
-
-      - name: Test clang-format-git-python
-        run: npx clang-format-git-python --help
-
-      - name: Test clang-format-node
+      - name: Basic test (Git Bash)
         run: |
           npx clang-format-node --help
           npx clang-format-node --version
+          npx clang-format-git --help
+          npx clang-format-git-python --help
+
+      - name: Windows PowerShell test
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          npx clang-format-node --help
+          npx clang-format-node --version
+          npx clang-format-git --help
+          npx clang-format-git-python --help
+
+      - name: Windows CMD test
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          npx clang-format-node --help
+          npx clang-format-node --version
+          npx clang-format-git --help
+          npx clang-format-git-python --help
 
   docker-images:
     strategy:


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/test-cross-platform.yml` file to enhance the testing process across different platforms. The changes mainly focus on expanding the test coverage to include various shell environments on Windows.

Enhancements to cross-platform testing:

* Added a basic test for `clang-format-node` and `clang-format-git` in the Git Bash environment.
* Included a new test for `clang-format-node` and `clang-format-git` in the Windows PowerShell environment, conditional on the runner operating system being Windows.
* Added a test for `clang-format-node` and `clang-format-git` in the Windows CMD environment, also conditional on the runner operating system being Windows.