### PR TITLE
feat: add API documentation links to type files (JSDoc type hints)

### DIFF
--- a/packages/clang-format-git-python/src/utils/gitClangFormatPath.js
+++ b/packages/clang-format-git-python/src/utils/gitClangFormatPath.js
@@ -20,6 +20,7 @@ const { resolve } = require('path');
  * @type string
  * @alias `clangFormatGitPythonPath`. See {@link clangFormatGitPythonPath}.
  * @version `v1.2.0` Initial release.
+ * @see https://clang-format-node.lumir.page/docs/apis/clang-format-git-python
  */
 const gitClangFormatPath = resolve(__dirname, `..`, `script`, `git-clang-format`);
 
@@ -28,6 +29,7 @@ const gitClangFormatPath = resolve(__dirname, `..`, `script`, `git-clang-format`
  *
  * @alias `gitClangFormatPath`. See {@link gitClangFormatPath}.
  * @version `v1.2.0` Initial release.
+ * @see https://clang-format-node.lumir.page/docs/apis/clang-format-git-python
  */
 const clangFormatGitPythonPath = gitClangFormatPath;
 

--- a/packages/clang-format-git/src/utils/getGitClangFormatPath.js
+++ b/packages/clang-format-git/src/utils/getGitClangFormatPath.js
@@ -28,6 +28,7 @@ const { resolve } = require('path');
  * @throws `Error` Throws an error if the executable binary is not found for the specified OS platform and architecture.
  * @alias `getClangFormatGitPath`. See {@link getClangFormatGitPath}.
  * @version `v1.2.0` Initial release.
+ * @see https://clang-format-node.lumir.page/docs/apis/clang-format-git
  */
 function getGitClangFormatPath(osPlatform, architecture) {
   const gitClangFormatPath = resolve(
@@ -51,6 +52,7 @@ function getGitClangFormatPath(osPlatform, architecture) {
  *
  * @alias `getGitClangFormatPath`. See {@link getGitClangFormatPath}.
  * @version `v1.2.0` Initial release.
+ * @see https://clang-format-node.lumir.page/docs/apis/clang-format-git
  */
 const getClangFormatGitPath = getGitClangFormatPath;
 

--- a/packages/clang-format-git/src/utils/gitClangFormatPath.js
+++ b/packages/clang-format-git/src/utils/gitClangFormatPath.js
@@ -21,6 +21,7 @@ const { getGitClangFormatPath } = require('./getGitClangFormatPath');
  *
  * @alias `clangFormatGitPath`. See {@link clangFormatGitPath}.
  * @version `v1.2.0` Initial release.
+ * @see https://clang-format-node.lumir.page/docs/apis/clang-format-git
  */
 const gitClangFormatPath = getGitClangFormatPath(platform(), arch());
 
@@ -29,6 +30,7 @@ const gitClangFormatPath = getGitClangFormatPath(platform(), arch());
  *
  * @alias `gitClangFormatPath`. See {@link gitClangFormatPath}.
  * @version `v1.2.0` Initial release.
+ * @see https://clang-format-node.lumir.page/docs/apis/clang-format-git
  */
 const clangFormatGitPath = gitClangFormatPath;
 

--- a/packages/clang-format-node/src/utils/clangFormatPath.js
+++ b/packages/clang-format-node/src/utils/clangFormatPath.js
@@ -21,6 +21,7 @@ const { getClangFormatPath } = require('./getClangFormatPath');
  *
  * @alias `clangFormatNodePath`. See {@link clangFormatNodePath}.
  * @version `v1.2.0` Initial release.
+ * @see https://clang-format-node.lumir.page/docs/apis/clang-format-node
  */
 const clangFormatPath = getClangFormatPath(platform(), arch());
 
@@ -29,6 +30,7 @@ const clangFormatPath = getClangFormatPath(platform(), arch());
  *
  * @alias `clangFormatPath`. See {@link clangFormatPath}.
  * @version `v1.2.0` Initial release.
+ * @see https://clang-format-node.lumir.page/docs/apis/clang-format-node
  */
 const clangFormatNodePath = clangFormatPath;
 

--- a/packages/clang-format-node/src/utils/getClangFormatPath.js
+++ b/packages/clang-format-node/src/utils/getClangFormatPath.js
@@ -28,6 +28,7 @@ const { resolve } = require('path');
  * @throws `Error` Throws an error if the executable binary is not found for the specified OS platform and architecture.
  * @alias `getClangFormatNodePath`. See {@link getClangFormatNodePath}.
  * @version `v1.2.0` Initial release.
+ * @see https://clang-format-node.lumir.page/docs/apis/clang-format-node
  */
 function getClangFormatPath(osPlatform, architecture) {
   const clangFormatPath = resolve(
@@ -51,6 +52,7 @@ function getClangFormatPath(osPlatform, architecture) {
  *
  * @alias `getClangFormatPath`. See {@link getClangFormatPath}.
  * @version `v1.2.0` Initial release.
+ * @see https://clang-format-node.lumir.page/docs/apis/clang-format-node
  */
 const getClangFormatNodePath = getClangFormatPath;
 


### PR DESCRIPTION
This pull request includes several changes to the documentation comments in various utility files across different packages. The changes primarily add references to the documentation URLs for the respective APIs.

Documentation improvements:

* [`packages/clang-format-git-python/src/utils/gitClangFormatPath.js`](diffhunk://#diff-0b92886b850ec05cf8174fb293fc1d7f26dfd6064e907bfc81e09da43c8e1e49R23): Added a reference to the documentation URL for `clang-format-git-python` in the comments for `gitClangFormatPath` and `clangFormatGitPythonPath`. [[1]](diffhunk://#diff-0b92886b850ec05cf8174fb293fc1d7f26dfd6064e907bfc81e09da43c8e1e49R23) [[2]](diffhunk://#diff-0b92886b850ec05cf8174fb293fc1d7f26dfd6064e907bfc81e09da43c8e1e49R32)
* [`packages/clang-format-git/src/utils/getGitClangFormatPath.js`](diffhunk://#diff-1bb2e643c38d95e89f5956f9701352544d048ce9b211521186d0aecda6a2b09bR31): Added a reference to the documentation URL for `clang-format-git` in the comments for `getGitClangFormatPath` and `getClangFormatGitPath`. [[1]](diffhunk://#diff-1bb2e643c38d95e89f5956f9701352544d048ce9b211521186d0aecda6a2b09bR31) [[2]](diffhunk://#diff-1bb2e643c38d95e89f5956f9701352544d048ce9b211521186d0aecda6a2b09bR55)
* [`packages/clang-format-git/src/utils/gitClangFormatPath.js`](diffhunk://#diff-1adcc2abfa385d5db149f797a576817728d4ddee81c1b9196d60ce4d8328390eR24): Added a reference to the documentation URL for `clang-format-git` in the comments for `gitClangFormatPath` and `clangFormatGitPath`. [[1]](diffhunk://#diff-1adcc2abfa385d5db149f797a576817728d4ddee81c1b9196d60ce4d8328390eR24) [[2]](diffhunk://#diff-1adcc2abfa385d5db149f797a576817728d4ddee81c1b9196d60ce4d8328390eR33)
* [`packages/clang-format-node/src/utils/clangFormatPath.js`](diffhunk://#diff-2fec3a5daf6d86f193c4f1bf1b809829a7471077b651f5233947089305a1371fR24): Added a reference to the documentation URL for `clang-format-node` in the comments for `clangFormatPath` and `clangFormatNodePath`. [[1]](diffhunk://#diff-2fec3a5daf6d86f193c4f1bf1b809829a7471077b651f5233947089305a1371fR24) [[2]](diffhunk://#diff-2fec3a5daf6d86f193c4f1bf1b809829a7471077b651f5233947089305a1371fR33)
* [`packages/clang-format-node/src/utils/getClangFormatPath.js`](diffhunk://#diff-69431841c8379c19bac868db91bce476be6122cca550dd2bb841a8fd7d050ebbR31): Added a reference to the documentation URL for `clang-format-node` in the comments for `getClangFormatPath` and `getClangFormatNodePath`. [[1]](diffhunk://#diff-69431841c8379c19bac868db91bce476be6122cca550dd2bb841a8fd7d050ebbR31) [[2]](diffhunk://#diff-69431841c8379c19bac868db91bce476be6122cca550dd2bb841a8fd7d050ebbR55)