### PR TITLE
ci: add `concurrency` settings to `lint.yml` and `test.yml` workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'main') }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'main') }}
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to add concurrency control for the `lint` and `test` jobs. The most important changes are:

GitHub Actions concurrency control:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R10-R13): Added concurrency control to the `lint` job to group by workflow and ref, and cancel in-progress runs for non-main branches.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R10-R13): Added concurrency control to the `test` job to group by workflow and ref, and cancel in-progress runs for non-main branches.