### PR TITLE
release(minor): v1.3.0

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-clang-format",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "scripts": {
     "formatted:c": "npx clang-format src/formatted.c",
     "formatted:c:dry-run": "npx clang-format -Werror -n src/formatted.c",
@@ -13,6 +13,6 @@
     "unformatted:cpp:dry-run": "npx clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.5"
+    "clang-format-node": "^1.3.0"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-git-clang-format",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "scripts": {
     "add-a-space-to-line-9-of-main-c-file": "cat src/main_overwrite.txt > src/main.c",
     "git-add": "git add src/main.c && git status",
     "git-clang-format": "npx git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.5"
+    "clang-format-git": "^1.3.0"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.2.5"
+  "version": "1.3.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,16 +36,16 @@
     },
     "examples/clang-format": {
       "name": "examples-clang-format",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "dependencies": {
-        "clang-format-node": "^1.2.5"
+        "clang-format-node": "^1.3.0"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "dependencies": {
-        "clang-format-git": "^1.2.5"
+        "clang-format-git": "^1.3.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -19222,11 +19222,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "1.2.5",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.2.5"
+        "clang-format-node": "^1.3.0"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -19237,11 +19237,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "1.2.5",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.2.5"
+        "clang-format-node": "^1.3.0"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -19252,7 +19252,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "1.2.5",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -19265,20 +19265,20 @@
     },
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "dependencies": {
-        "clang-format-git": "^1.2.5",
-        "clang-format-git-python": "^1.2.5",
-        "clang-format-node": "^1.2.5"
+        "clang-format-git": "^1.3.0",
+        "clang-format-git-python": "^1.3.0",
+        "clang-format-node": "^1.3.0"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "dependencies": {
-        "clang-format-git": "^1.2.5",
-        "clang-format-git-python": "^1.2.5",
-        "clang-format-node": "^1.2.5"
+        "clang-format-git": "^1.3.0",
+        "clang-format-git-python": "^1.3.0",
+        "clang-format-node": "^1.3.0"
       }
     },
     "tests/integration-binaries-perimission": {
@@ -19291,11 +19291,11 @@
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "dependencies": {
-        "clang-format-git": "^1.2.5",
-        "clang-format-git-python": "^1.2.5",
-        "clang-format-node": "^1.2.5"
+        "clang-format-git": "^1.3.0",
+        "clang-format-git-python": "^1.3.0",
+        "clang-format-node": "^1.3.0"
       }
     },
     "tests/integration-cjs": {
@@ -19331,7 +19331,7 @@
       }
     },
     "website": {
-      "version": "1.2.5",
+      "version": "1.3.0",
       "devDependencies": {
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^1.6.1",

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -53,6 +53,6 @@
     "chmod": "find ./src/script ./build/script -type f -exec chmod 755 {} + || exit 0"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.5"
+    "clang-format-node": "^1.3.0"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -52,6 +52,6 @@
     "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || exit 0"
   },
   "dependencies": {
-    "clang-format-node": "^1.2.5"
+    "clang-format-node": "^1.3.0"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-cjs",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "type": "commonjs",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.5",
-    "clang-format-git-python": "^1.2.5",
-    "clang-format-node": "^1.2.5"
+    "clang-format-git": "^1.3.0",
+    "clang-format-git-python": "^1.3.0",
+    "clang-format-node": "^1.3.0"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-esm",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.5",
-    "clang-format-git-python": "^1.2.5",
-    "clang-format-node": "^1.2.5"
+    "clang-format-git": "^1.3.0",
+    "clang-format-git-python": "^1.3.0",
+    "clang-format-node": "^1.3.0"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "tests-integration-binaries-permission",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.2.5",
-    "clang-format-git-python": "^1.2.5",
-    "clang-format-node": "^1.2.5"
+    "clang-format-git": "^1.3.0",
+    "clang-format-git-python": "^1.3.0",
+    "clang-format-node": "^1.3.0"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "scripts": {
     "dev": "npx vitepress --open --host",
     "build": "npx vitepress build --outDir build",


### PR DESCRIPTION
Bump `lumirlumir/npm-clang-format-node` from v1.2.5 to v1.3.0 :tada: