### PR TITLE
docs: fix a typo

### DIFF
--- a/website/docs/get-started/introduction.md
+++ b/website/docs/get-started/introduction.md
@@ -17,7 +17,7 @@ description: 'This page introduces the concepts and provides guidance on how to 
 
 :::
 
-> [!NOTE] Reference
+> [!NOTE] References
 >
 > - [Format your code - all the time](https://ortogonal.github.io/cpp/git-clang-format/)
 > - [Surgical formatting with `git-clang-format`](https://offlinemark.com/surgical-formatting-with-git-clang-format/)


### PR DESCRIPTION
This pull request includes a minor change to the `website/docs/get-started/introduction.md` file. The change corrects a grammatical error in a note section.

* [`website/docs/get-started/introduction.md`](diffhunk://#diff-aeb0fea669d0b87f99bf331106ddc13e198f254aa732266a2435acf9a98f82aaL20-R20): Changed "Reference" to "References" to correct the grammar in the note section.