### PR TITLE
chore: add `vercel-ignore-command.sh` script and update `vercel.json` configuration

### DIFF
--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -42,6 +42,9 @@ lumirlumir/lumirlumir-configs:
     dest: ./configs/.vscode/npm-extensions.json
   - source: ./.vscode/settings.json
     dest: ./configs/.vscode/settings.json
+  # ./scripts
+  - source: ./scripts/vercel-ignore-command.sh
+    dest: ./configs/scripts/vercel-ignore-command.sh
   # ./
   - source: ./.editorconfig
     dest: ./configs/.editorconfig

--- a/scripts/vercel-ignore-command.sh
+++ b/scripts/vercel-ignore-command.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# If the PR is created by `dependabot[bot]` and the branch is not `main`, ignore the build.
+if [ "$VERCEL_GIT_COMMIT_AUTHOR_LOGIN" = "dependabot[bot]" ] && [ "$VERCEL_GIT_COMMIT_REF" != "main" ]; then
+  echo "🛑 Ignoring build for dependabot[bot] PR (branch: $VERCEL_GIT_COMMIT_REF, author: $VERCEL_GIT_COMMIT_AUTHOR_LOGIN)"
+  exit 0 # Return `0` to skip the build.
+fi
+
+# Proceed with the build in other cases.
+echo "✅ Proceeding with the build (branch: $VERCEL_GIT_COMMIT_REF, author: $VERCEL_GIT_COMMIT_AUTHOR_LOGIN)"
+exit 1 # Return `1` to proceed with build.

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,3 +1,8 @@
 {
-  "cleanUrls": true
+  "buildCommand": "npm run build",
+  "cleanUrls": true,
+  "framework": "vitepress",
+  "ignoreCommand": "bash  ../scripts/vercel-ignore-command.sh",
+  "installCommand": "npm install --prefix ..",
+  "outputDirectory": "build"
 }


### PR DESCRIPTION
This pull request includes changes to add a new script for Vercel build ignoring, update the Vercel configuration, and modify the sync client configuration. The most important changes are:

### New Script Addition:
* Added a new script `vercel-ignore-command.sh` to ignore builds for pull requests created by `dependabot[bot]` if the branch is not `main`.

### Vercel Configuration Updates:
* Updated `vercel.json` to include the new `ignoreCommand`, set the build and install commands, specify the framework as `vitepress`, and define the output directory.

### Sync Client Configuration Update:
* Updated `.github/sync-client.yml` to include the new script in the sync process.