### PR TITLE
fix(ci): update `llvm-build-bump-pr.yml` LLVM build script to include static linking flags on Windows

### DIFF
--- a/.github/workflows/llvm-build-bump-pr.yml
+++ b/.github/workflows/llvm-build-bump-pr.yml
@@ -369,7 +369,7 @@ jobs:
       # packages:clang-format-node
 
       - name: Build cmake
-        run: cmake -S llvm -B build -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=MinSizeRel
+        run: cmake -S llvm -B build -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++"
 
       - name: Build clang-format
         run: ninja -C build clang-format


### PR DESCRIPTION
This PR is the follow up PR of #206

Added static link for `libgcc_s_seh-1.dll`, `libwinpthread-1.dll`, and `libstdc++-6.dll`.

This updates only affect Windows binary.

---

This pull request includes a change to the `.github/workflows/llvm-build-bump-pr.yml` file to enhance the build process for `clang-format`. The most important change is the addition of static linking flags to the CMake build command.

Build process enhancement:

* [`.github/workflows/llvm-build-bump-pr.yml`](diffhunk://#diff-d608eb75b383338d789a8908995e47499214a7cc55a847771ad73800464b18b0L372-R372): Modified the CMake build command to include `-DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++"` for static linking.