### PR TITLE
docs: correct GitHub PR list link in `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Some may have concerns about the security of binary files, but the following poi
 1. Second, our build processes are fully transparent. You can review exactly how these binaries are built and track the pull requests showing their origins.
 
     - See [`llvm-build-bump-pr.yml`](https://github.com/lumirlumir/npm-clang-format-node/blob/main/.github/workflows/llvm-build-bump-pr.yml).
-    - See the [Pull Request list on GitHub](https://github.com/lumirlumir/npm-clang-format-node/pulls?q=is%3Apr+%28deps%29%3A+bump+LLVM+from).
+    - See the [Pull Request list on GitHub](https://github.com/lumirlumir/npm-clang-format-node/pulls?q=is%3Apr+%28deps%29%3A+bump+LLVM+from+label%3Adependencies).
 
 1. Third, when you run the command `clang-format --version`, you can verify the current **LLVM version**, **repository URL**, and **commit SHA**, as shown below:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Some may have concerns about the security of binary files, but the following poi
 1. Second, our build processes are fully transparent. You can review exactly how these binaries are built and track the pull requests showing their origins.
 
     - See [`llvm-build-bump-pr.yml`](https://github.com/lumirlumir/npm-clang-format-node/blob/main/.github/workflows/llvm-build-bump-pr.yml).
-    - See the [Pull Request list on GitHub](https://github.com/lumirlumir/npm-clang-format-node/pulls?q=is%3Apr+is%3Aclosed+llvm+build%28deps%29%3A+bump+LLVM).
+    - See the [Pull Request list on GitHub](https://github.com/lumirlumir/npm-clang-format-node/pulls?q=is%3Apr+%28deps%29%3A+bump+LLVM+from).
 
 1. Third, when you run the command `clang-format --version`, you can verify the current **LLVM version**, **repository URL**, and **commit SHA**, as shown below:
 


### PR DESCRIPTION
This pull request includes a minor update to the `SECURITY.md` file to improve the clarity of the instructions for reviewing pull requests related to LLVM builds.

Documentation update:

* [`SECURITY.md`](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L12-R12): Updated the link to the Pull Request list on GitHub to use a more specific query for filtering pull requests related to LLVM dependency bumps.