### PR TITLE
ci: add `concurrency` settings to GitHub Actions `labeler.yml` workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   labeler:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to add concurrency control. The most important change is the addition of a concurrency group to the `labeler` job in the `.github/workflows/labeler.yml` file.

Improvements to GitHub Actions workflow:

* [`.github/workflows/labeler.yml`](diffhunk://#diff-09b72f3c9a3e4f00ab00cd7000b302db25f056075d8895bd91b3654d6e7e956bR7-R10): Added `concurrency` with `group` and `cancel-in-progress` to manage concurrent runs of the workflow.