### PR TITLE
chore: update `eslint-config-bananass` to version `0.0.2` and add `bananass-utils-vitepress` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "concurrently": "^9.0.0",
         "editorconfig-checker": "^6.0.0",
         "eslint": "^9.19.0",
-        "eslint-config-bananass": "^0.0.1",
+        "eslint-config-bananass": "^0.0.2",
         "husky": "^9.1.5",
         "lerna": "^8.1.9",
         "lint-staged": "^15.4.3",
@@ -4711,9 +4711,9 @@
       "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.13.0.tgz",
-      "integrity": "sha512-GPPDK4+fcbsQD58a3abbng2Dx+jBoxM5cnYjBM4T24WFZRZdlNSKvR19TxP8CPevzMOodQ9QVzNeqWvMXzfJRA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-3.0.1.tgz",
+      "integrity": "sha512-hjp6BKXSUdlY4l20pDb0EjIB5PtQDGihk2EUKCjJ5gaRVfcmMMkaIyVd/yK3oH7OLxWWBxJ8qSSo+zEdkmpnYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6053,6 +6053,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bananass-utils-vitepress": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/bananass-utils-vitepress/-/bananass-utils-vitepress-0.0.0.tgz",
+      "integrity": "sha512-HrfxwGIGMy0ReMn0q6CRxcEqXBXAs13wOCkqHJB+M68iW1pSjpRT6ft8/VSKv+IFHIXe5G9pessVxAN5DI/3vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -8369,13 +8379,13 @@
       }
     },
     "node_modules/eslint-config-bananass": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-bananass/-/eslint-config-bananass-0.0.1.tgz",
-      "integrity": "sha512-94MOh1hXNd2IDJ7+b8EJGAeeVD8XMaYTd/MPNnFeou3fE35ydcJ5iLrRCvzQOpruwJqxohcg71+nG1nRUTXNKA==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-bananass/-/eslint-config-bananass-0.0.2.tgz",
+      "integrity": "sha512-M4+ZAKbTBI5L0aIzd/ClaFTDARgR8MnnBasChCPkk2ENnpjqk0kKSkRwRFwjqx0P1E35sw9m5MBniS00U3Uw8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@stylistic/eslint-plugin-js": "^2.13.0",
+        "@stylistic/eslint-plugin-js": "^3.0.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-n": "^17.15.1",
         "globals": "^15.14.0"
@@ -19631,6 +19641,7 @@
     "website": {
       "version": "1.3.0",
       "devDependencies": {
+        "bananass-utils-vitepress": "^0.0.0",
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^1.6.3",
         "vitepress-plugin-group-icons": "^1.3.5"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "concurrently": "^9.0.0",
     "editorconfig-checker": "^6.0.0",
     "eslint": "^9.19.0",
-    "eslint-config-bananass": "^0.0.1",
+    "eslint-config-bananass": "^0.0.2",
     "husky": "^9.1.5",
     "lerna": "^8.1.9",
     "lint-staged": "^15.4.3",

--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -4,12 +4,11 @@
  * @see https://vitepress.dev/reference/site-config#site-config
  */
 
-/* eslint-disable import/no-extraneous-dependencies -- TODO: Delete it after this rule is updated in `eslint-config-bananass` */
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------
 
+import { generateGoogleAnalyticsScript } from 'bananass-utils-vitepress/head';
 import footnote from 'markdown-it-footnote';
 import { defineConfig } from 'vitepress';
 import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons';
@@ -71,18 +70,7 @@ export default defineConfig({
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
 
     // Google Analytics
-    [
-      'script',
-      { async: '', src: `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_GA_ID}` },
-    ],
-    [
-      'script',
-      {},
-      `window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', '${GOOGLE_GA_ID}');`,
-    ],
+    ...generateGoogleAnalyticsScript(GOOGLE_GA_ID),
   ],
   lang: 'en-US',
 

--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,7 @@
     "start": "npx vitepress preview"
   },
   "devDependencies": {
+    "bananass-utils-vitepress": "^0.0.0",
     "markdown-it-footnote": "^4.0.0",
     "vitepress": "^1.6.3",
     "vitepress-plugin-group-icons": "^1.3.5"


### PR DESCRIPTION
This pull request includes updates to dependencies and refactoring of the Google Analytics script in the VitePress configuration.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L50-R50): Updated `eslint-config-bananass` to version `^0.0.2`.
* [`website/package.json`](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76R11): Added `bananass-utils-vitepress` as a new dependency.

### Refactoring:
* [`website/.vitepress/config.mjs`](diffhunk://#diff-bd4ac01d4c35583e9c20414103304b0628a6be199987bd1084fdef61cd43cc71L7-R11): Removed the `eslint-disable` comment and imported `generateGoogleAnalyticsScript` from `bananass-utils-vitepress/head`.
* [`website/.vitepress/config.mjs`](diffhunk://#diff-bd4ac01d4c35583e9c20414103304b0628a6be199987bd1084fdef61cd43cc71L74-R73): Replaced the inline Google Analytics script with a call to `generateGoogleAnalyticsScript`.