### PR TITLE
fix: support for Windows (build script failures, runtime failures, updates) (original: #206)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "markdownlint-cli": "^0.44.0",
         "prettier": "^3.3.3",
         "prettier-config-bananass": "^0.0.1",
+        "shx": "^0.3.4",
         "textlint": "^14.3.0",
         "textlint-rule-allowed-uris": "^1.0.6",
         "typescript": "^5.6.3"
@@ -10492,6 +10493,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -16354,6 +16365,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -16963,6 +16986,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/shiki": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.1.0.tgz",
@@ -16978,6 +17019,23 @@
         "@shikijs/types": "2.1.0",
         "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "markdownlint-cli": "^0.44.0",
     "prettier": "^3.3.3",
     "prettier-config-bananass": "^0.0.1",
+    "shx": "^0.3.4",
     "textlint": "^14.3.0",
     "textlint-rule-allowed-uris": "^1.0.6",
     "typescript": "^5.6.3"

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -45,12 +45,12 @@
     "node": ">=16"
   },
   "scripts": {
-    "postinstall": "test -d src && npm run build || npm run chmod",
+    "postinstall": "shx test -d src && npm run build || npm run chmod",
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build && npx tsc && cp -r src/script build && cp ../../LICENSE.md ../../README.md .",
+    "build": "npx babel src -d build && npx tsc && shx cp -r src/script build && shx cp ../../LICENSE.md ../../README.md .",
     "postbuild": "npm run chmod",
     "test": "node --test",
-    "chmod": "find ./src/script ./build/script -type f -exec chmod 755 {} + || exit 0",
+    "chmod": "shx chmod 755 ./src/script/**/* ./build/script/**/* || exit 0",
     "dev": "node src/cli.js",
     "start": "node build/cli.js"
   },

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -44,12 +44,12 @@
     "node": ">=16"
   },
   "scripts": {
-    "postinstall": "test -d src && npm run build || npm run chmod",
+    "postinstall": "shx test -d src && npm run build || npm run chmod",
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build && npx tsc && cp -r src/bin build && cp ../../LICENSE.md ../../README.md .",
+    "build": "npx babel src -d build && npx tsc && shx cp -r src/bin build && shx cp ../../LICENSE.md ../../README.md .",
     "postbuild": "npm run chmod",
     "test": "node --test",
-    "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || exit 0",
+    "chmod": "shx chmod 755 ./src/bin/**/* ./build/bin/**/* || exit 0",
     "dev": "node src/cli.js",
     "start": "node build/cli.js"
   },

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -43,12 +43,12 @@
     "node": ">=16"
   },
   "scripts": {
-    "postinstall": "test -d src && npm run build || npm run chmod",
+    "postinstall": "shx test -d src && npm run build || npm run chmod",
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build && npx tsc && cp -r src/bin build && cp ../../LICENSE.md ../../README.md .",
+    "build": "npx babel src -d build && npx tsc && shx cp -r src/bin build && shx cp ../../LICENSE.md ../../README.md .",
     "postbuild": "npm run chmod",
     "test": "node --test",
-    "chmod": "find ./src/bin ./build/bin -type f -exec chmod 755 {} + || exit 0",
+    "chmod": "shx chmod 755 ./src/bin/**/* ./build/bin/**/* || exit 0",
     "dev": "node src/cli.js",
     "start": "node build/cli.js"
   }


### PR DESCRIPTION
See https://github.com/lumirlumir/npm-clang-format-node/pull/206 for details.