### PR TITLE
chore(examples-git-clang-format): update script to use `shx` for cross-platform compatibility and add `shx` as a `devDependencies`

### DIFF
--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -3,7 +3,7 @@
   "name": "examples-git-clang-format",
   "version": "1.3.1",
   "scripts": {
-    "add-a-space-to-line-9-of-main-c-file": "cat src/main_overwrite.txt > src/main.c",
+    "add-a-space-to-line-9-of-main-c-file": "shx cat src/main_overwrite.txt > src/main.c",
     "git-add": "git add src/main.c && git status",
     "git-clang-format": "npx git-clang-format"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "markdownlint-cli": "^0.44.0",
         "prettier": "^3.3.3",
         "prettier-config-bananass": "^0.0.1",
+        "shx": "^0.3.4",
         "textlint": "^14.3.0",
         "textlint-rule-allowed-uris": "^1.0.6",
         "typescript": "^5.6.3"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "markdownlint-cli": "^0.44.0",
     "prettier": "^3.3.3",
     "prettier-config-bananass": "^0.0.1",
+    "shx": "^0.3.4",
     "textlint": "^14.3.0",
     "textlint-rule-allowed-uris": "^1.0.6",
     "typescript": "^5.6.3"


### PR DESCRIPTION
This pull request includes updates to the `package.json` files to use the `shx` utility for cross-platform shell commands. The most important changes are:

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R57): Added `shx` as a dependency to the project.

Script updates:

* [`examples/git-clang-format/package.json`](diffhunk://#diff-4b5616cba814f4c7ca4ea49c77e8456efcc7931852306a3d899597507ad137b6L6-R6): Updated the `add-a-space-to-line-9-of-main-c-file` script to use `shx` for improved cross-platform compatibility.