### PR TITLE
docs(website): fix a small typo

### DIFF
--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -89,7 +89,7 @@ export default defineConfig({
     hostname: SITE_URL,
   },
 
-  /* Thme Configuration */
+  /* Theme Configuration */
   themeConfig: {
     logo: {
       light: '/logo-black.svg',


### PR DESCRIPTION
This pull request includes a minor correction in the `website/.vitepress/config.mjs` file. The change fixes a typo in a comment.

* [`website/.vitepress/config.mjs`](diffhunk://#diff-bd4ac01d4c35583e9c20414103304b0628a6be199987bd1084fdef61cd43cc71L92-R92): Corrected the typo from "Thme Configuration" to "Theme Configuration".