### PR TITLE
chore(*): enable `checkJs` option in TypeScript configuration for a better type checking

### DIFF
--- a/packages/clang-format-git-python/tsconfig.json
+++ b/packages/clang-format-git-python/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
+    "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "build"

--- a/packages/clang-format-git/tsconfig.json
+++ b/packages/clang-format-git/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
+    "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "build"

--- a/packages/clang-format-node/tsconfig.json
+++ b/packages/clang-format-node/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
+    "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "build"


### PR DESCRIPTION
This pull request includes changes to the `tsconfig.json` files across multiple packages to enable JavaScript type checking. The most important changes include updating the `compilerOptions` to set `checkJs` to true.

Updates to `tsconfig.json` files:

* [`packages/clang-format-git-python/tsconfig.json`](diffhunk://#diff-da952c9797a8b0e14c1f27481ae421251f0a72d0e83c8f633293783174f619deR4): Added `"checkJs": true` to `compilerOptions`.
* [`packages/clang-format-git/tsconfig.json`](diffhunk://#diff-da952c9797a8b0e14c1f27481ae421251f0a72d0e83c8f633293783174f619deR4): Added `"checkJs": true` to `compilerOptions`.
* [`packages/clang-format-node/tsconfig.json`](diffhunk://#diff-da952c9797a8b0e14c1f27481ae421251f0a72d0e83c8f633293783174f619deR4): Added `"checkJs": true` to `compilerOptions`.