### PR TITLE
chore(*): add `publishConfig` with `provenance` set to `true` in `package.json` files

### DIFF
--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -44,6 +44,9 @@
   "engines": {
     "node": ">=16"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "postinstall": "shx test -d src && npm run build || npm run chmod",
     "prepublishOnly": "npm run build",

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -43,6 +43,9 @@
   "engines": {
     "node": ">=16"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "postinstall": "shx test -d src && npm run build || npm run chmod",
     "prepublishOnly": "npm run build",

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -42,6 +42,9 @@
   "engines": {
     "node": ">=16"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "postinstall": "shx test -d src && npm run build || npm run chmod",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
This pull request includes changes to the `package.json` files of three different packages to add a `publishConfig` section. This section ensures that the packages are published with provenance information.

Changes to `package.json` files:

* [`packages/clang-format-git-python/package.json`](diffhunk://#diff-fb0eb5dba5b2656b3fdea4322c2ed2a691973f2e9ea536ce20b36c347ab1267eR47-R49): Added a `publishConfig` section with `provenance` set to true.
* [`packages/clang-format-git/package.json`](diffhunk://#diff-d85dcfb0934f579cff896723ab5eeb9a52668d2bb322338dddd93bc1241aa4f1R46-R48): Added a `publishConfig` section with `provenance` set to true.
* [`packages/clang-format-node/package.json`](diffhunk://#diff-6e04d643c57b851ab02ad78e41531387d2cc01caf6c4cfbaa536aadd37346a30R45-R47): Added a `publishConfig` section with `provenance` set to true.