### PR TITLE
chore(*): remove `.spec.js` files from exclusion and ignore lists

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: ['@babel/preset-env'],
-  ignore: ['**/*.test.js', '**/*.spec.js'],
+  ignore: ['**/*.test.js'],
   minified: true,
   comments: false,
 };

--- a/packages/clang-format-git-python/tsconfig.json
+++ b/packages/clang-format-git-python/tsconfig.json
@@ -7,5 +7,5 @@
     "outDir": "build"
   },
   "include": ["src/**/*.js"],
-  "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]
+  "exclude": ["src/**/*.test.js"]
 }

--- a/packages/clang-format-git/tsconfig.json
+++ b/packages/clang-format-git/tsconfig.json
@@ -7,5 +7,5 @@
     "outDir": "build"
   },
   "include": ["src/**/*.js"],
-  "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]
+  "exclude": ["src/**/*.test.js"]
 }

--- a/packages/clang-format-node/tsconfig.json
+++ b/packages/clang-format-node/tsconfig.json
@@ -7,5 +7,5 @@
     "outDir": "build"
   },
   "include": ["src/**/*.js"],
-  "exclude": ["src/**/*.test.js", "src/**/*.spec.js"]
+  "exclude": ["src/**/*.test.js"]
 }


### PR DESCRIPTION
This pull request includes changes to the configuration files to adjust the exclusion patterns for test files. The most important changes involve modifying the `ignore` and `exclude` properties in various configuration files to no longer exclude `*.spec.js` files.

Configuration updates:

* [`babel.config.js`](diffhunk://#diff-09c56b2bf95de2a608a36afef3b6893146a959d6739be0a154dc9c9f02d80f24L3-R3): Updated the `ignore` property to only exclude `*.test.js` files.
* [`packages/clang-format-git-python/tsconfig.json`](diffhunk://#diff-da952c9797a8b0e14c1f27481ae421251f0a72d0e83c8f633293783174f619deL10-R10): Updated the `exclude` property to only exclude `*.test.js` files.
* [`packages/clang-format-git/tsconfig.json`](diffhunk://#diff-da952c9797a8b0e14c1f27481ae421251f0a72d0e83c8f633293783174f619deL10-R10): Updated the `exclude` property to only exclude `*.test.js` files.
* [`packages/clang-format-node/tsconfig.json`](diffhunk://#diff-da952c9797a8b0e14c1f27481ae421251f0a72d0e83c8f633293783174f619deL10-R10): Updated the `exclude` property to only exclude `*.test.js` files.