### PR TITLE
chore(*): update `publish-package` script to use `next` pre-dist tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "prepare": "husky",
-    "publish-package": "npx lerna publish from-package --pre-dist-tag canary --yes",
+    "publish-package": "npx lerna publish from-package --pre-dist-tag next --yes",
     "test": "npx lerna run test --concurrency 1",
     "coverage": "npx c8 --reporter=lcov npm run test",
     "build": "npx lerna run build",


### PR DESCRIPTION
This pull request includes a small but important change to the `package.json` file. The change updates the `publish-package` script to use a different pre-distribution tag.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R15): Changed the `publish-package` script to use `next` instead of `canary` as the pre-distribution tag.