### PR TITLE
chore(release): bump package versions from `v1.3.1` to `v1.3.2` (`patch`)

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-clang-format",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "scripts": {
     "formatted:c": "npx clang-format src/formatted.c",
     "formatted:c:dry-run": "npx clang-format -Werror -n src/formatted.c",
@@ -13,6 +13,6 @@
     "unformatted:cpp:dry-run": "npx clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^1.3.1"
+    "clang-format-node": "^1.3.2"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-git-clang-format",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "scripts": {
     "add-a-space-to-line-9-of-main-c-file": "shx cat src/main_overwrite.txt > src/main.c",
     "git-add": "git add src/main.c && git status",
     "git-clang-format": "npx git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.1"
+    "clang-format-git": "^1.3.2"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,16 +37,16 @@
     },
     "examples/clang-format": {
       "name": "examples-clang-format",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
-        "clang-format-node": "^1.3.1"
+        "clang-format-node": "^1.3.2"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
-        "clang-format-git": "^1.3.1"
+        "clang-format-git": "^1.3.2"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -16546,20 +16546,6 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -17478,14 +17464,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -20435,11 +20413,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.3.1",
+        "clang-format-node": "^1.3.2",
         "shx": "^0.3.4"
       },
       "bin": {
@@ -20451,11 +20429,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.3.1",
+        "clang-format-node": "^1.3.2",
         "shx": "^0.3.4"
       },
       "bin": {
@@ -20467,7 +20445,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -20483,20 +20461,20 @@
     },
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
-        "clang-format-git": "^1.3.1",
-        "clang-format-git-python": "^1.3.1",
-        "clang-format-node": "^1.3.1"
+        "clang-format-git": "^1.3.2",
+        "clang-format-git-python": "^1.3.2",
+        "clang-format-node": "^1.3.2"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
-        "clang-format-git": "^1.3.1",
-        "clang-format-git-python": "^1.3.1",
-        "clang-format-node": "^1.3.1"
+        "clang-format-git": "^1.3.2",
+        "clang-format-git-python": "^1.3.2",
+        "clang-format-node": "^1.3.2"
       }
     },
     "tests/integration-binaries-perimission": {
@@ -20509,11 +20487,11 @@
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
-        "clang-format-git": "^1.3.1",
-        "clang-format-git-python": "^1.3.1",
-        "clang-format-node": "^1.3.1"
+        "clang-format-git": "^1.3.2",
+        "clang-format-git-python": "^1.3.2",
+        "clang-format-node": "^1.3.2"
       }
     },
     "tests/integration-cjs": {
@@ -20549,7 +20527,7 @@
       }
     },
     "website": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "devDependencies": {
         "bananass-utils-vitepress": "^0.0.0",
         "markdown-it-footnote": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16546,6 +16546,20 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -58,7 +58,7 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^1.3.1",
+    "clang-format-node": "^1.3.2",
     "shx": "^0.3.4"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -57,7 +57,7 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^1.3.1",
+    "clang-format-node": "^1.3.2",
     "shx": "^0.3.4"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-cjs",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "commonjs",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.1",
-    "clang-format-git-python": "^1.3.1",
-    "clang-format-node": "^1.3.1"
+    "clang-format-git": "^1.3.2",
+    "clang-format-git-python": "^1.3.2",
+    "clang-format-node": "^1.3.2"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-esm",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.1",
-    "clang-format-git-python": "^1.3.1",
-    "clang-format-node": "^1.3.1"
+    "clang-format-git": "^1.3.2",
+    "clang-format-git-python": "^1.3.2",
+    "clang-format-node": "^1.3.2"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "tests-integration-binaries-permission",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.1",
-    "clang-format-git-python": "^1.3.1",
-    "clang-format-node": "^1.3.1"
+    "clang-format-git": "^1.3.2",
+    "clang-format-git-python": "^1.3.2",
+    "clang-format-node": "^1.3.2"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "scripts": {
     "dev": "npx vitepress --open --host",
     "build": "npx vitepress build --outDir build",


### PR DESCRIPTION
## Release Information: `v1.3.2`

New release of `lumirlumir/npm-clang-format-node` has arrived! :tada:

This PR bumps the package versions from `v1.3.1` to `v1.3.2` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-clang-format-node/actions/runs/13613429578) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-clang-format-node` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 006d2eb       |
| Old Version | `v1.3.1`  |
| New Version | `v1.3.2`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :toolbox: Chores
* chore(examples-git-clang-format): update script to use `shx` for cross-platform compatibility and add `shx` as a `devDependencies` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/217
* chore(*): enable `checkJs` option in TypeScript configuration for a better type checking by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/228
* chore(*): set `open-pull-requests-limit` to 3 in `dependabot.yml` configuration by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/231
* chore(*): add `publishConfig` with `provenance` set to `true` in `package.json` files by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/235
* chore(sync-server): update `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/236
* chore(*): remove `.spec.js` files from exclusion and ignore lists by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/237
* chore(sync-server): update `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/245
* chore(*): update `publish-package` script to use `next` pre-dist tag by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/246
### :arrows_counterclockwise: Continuous Integrations
* ci(*): create `pull-request.yml` and update `labeler` logics by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/219
* ci(sync-server): update `.github/release.yml` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/218
* ci(sync-server): update `pull-request.yml` to include `synchronize` event by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/220
* ci(*): update `dependabot.yml` commit message type and `pull-request.yml` labeler condition by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/221
* ci(sync-server): update `pull-request.yml`'s `concurrency` and `sync-client.yml` commit prefix by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/224
* ci(*): drop `bump.yml` and create new `version-monorepo.yml` workflow by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/247
### :memo: Documentation
* docs(website): fix a small typo by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/226
### :arrow_up: Dependency Updates
* chore(deps-dev): bump eslint from 9.19.0 to 9.20.0 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/223
* chore(deps-dev): bump the babel group across 1 directory with 2 updates by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/222
* chore(deps-dev): bump prettier from 3.4.2 to 3.5.0 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/225
* chore(deps-dev): bump eslint from 9.20.0 to 9.20.1 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/227
* chore(deps-dev): bump prettier from 3.5.0 to 3.5.1 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/229
* chore(deps-dev): bump @types/node from 22.13.1 to 22.13.4 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/230
* chore(deps-dev): bump the babel group across 1 directory with 2 updates by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/232
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.3.5 to 1.3.6 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/233
* chore(deps-dev): bump lerna from 8.1.9 to 8.2.0 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/238
* chore(deps-dev): bump eslint-config-bananass from `0.0.2` to `0.0.5` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/240
* chore(deps-dev): bump @types/node from 22.13.4 to 22.13.5 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/241
* chore(deps-dev): bump prettier from 3.5.1 to 3.5.2 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/242
* chore(deps-dev): bump eslint from 9.20.1 to 9.21.0 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/243
* chore(deps-dev): bump textlint-rule-allowed-uris from 1.0.7 to 1.0.8 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/244


**Full Changelog**: https://github.com/lumirlumir/npm-clang-format-node/compare/v1.3.1...v1.3.2