### PR TITLE
ci(*): add `id-token` write permission to `publish.yml`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish.yml` file. The change adds permissions for `id-token` to the workflow configuration.