### PR TITLE
ci(*): add read permissions to `test-cross-platform.yml`

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - '**/*.md'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'main') }}


### PR DESCRIPTION
This pull request includes a small but important change to the GitHub Actions workflow configuration file `.github/workflows/test-cross-platform.yml`. The change grants read permissions to the contents of the repository.

* [`.github/workflows/test-cross-platform.yml`](diffhunk://#diff-290907d9a4bcf13181105b134bd1645da5a3ef27c54f148ad5823e6b77e88426R14-R16): Added `permissions` section to grant read access to repository contents.