### PR TITLE
ci(*): update `llvm-build-bump-pr.yml` to add `permissions` and disable `fail-fast` strategy

### DIFF
--- a/.github/workflows/llvm-build-bump-pr.yml
+++ b/.github/workflows/llvm-build-bump-pr.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '0 1 * * 1'
 
+permissions:
+  contents: read
+
 env:
   GH_TOKEN: ${{ secrets.GH_PAT }}
   LLVM_REPO: llvm/llvm-project
@@ -138,6 +141,7 @@ jobs:
   # Linux-qemu(cross-platform)
   stage2-build-linux-qemu:
     strategy:
+      fail-fast: false
       matrix:
         docker:
           - platform: arm/v7
@@ -243,6 +247,7 @@ jobs:
   # MacOS
   stage2-build-darwin:
     strategy:
+      fail-fast: false
       matrix:
         type:
           - macos-14 # arm64 (macos-latest: arm64)


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for the LLVM build process. The main changes involve adding permissions and modifying job strategies to improve the workflow's robustness and security.

Workflow improvements:

* [`.github/workflows/llvm-build-bump-pr.yml`](diffhunk://#diff-d608eb75b383338d789a8908995e47499214a7cc55a847771ad73800464b18b0R15-R17): Added `contents: read` permission to the workflow to enhance security.
* [`.github/workflows/llvm-build-bump-pr.yml`](diffhunk://#diff-d608eb75b383338d789a8908995e47499214a7cc55a847771ad73800464b18b0R144): Set `fail-fast: false` in the strategy for the `stage2-build-linux-qemu` job to prevent the entire job matrix from failing on a single failure.
* [`.github/workflows/llvm-build-bump-pr.yml`](diffhunk://#diff-d608eb75b383338d789a8908995e47499214a7cc55a847771ad73800464b18b0R250): Set `fail-fast: false` in the strategy for the `stage2-build-darwin` job to prevent the entire job matrix from failing on a single failure.