### PR TITLE
chore(website): conditionally enable bundle analysis in Codecov Vite plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20763,9 +20763,23 @@
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
         "bananass-utils-vitepress": "^0.0.0",
+        "is-interactive": "^2.0.0",
         "markdown-it-footnote": "^4.0.0",
         "vitepress": "^1.6.3",
         "vitepress-plugin-group-icons": "^1.3.6"
+      }
+    },
+    "website/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -338,7 +338,7 @@ export default defineConfig({
       groupIconVitePlugin(),
       codecovVitePlugin({
         // Put the Codecov vite plugin after all other plugins
-        enableBundleAnalysis: true,
+        enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
         bundleName: 'website',
         uploadToken: process.env.CODECOV_TOKEN,
         gitService: 'github',

--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -13,6 +13,7 @@ import footnote from 'markdown-it-footnote';
 import { defineConfig } from 'vitepress';
 import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons';
 import { codecovVitePlugin } from '@codecov/vite-plugin';
+import isInteractive from 'is-interactive';
 
 // --------------------------------------------------------------------------------
 // Constants
@@ -338,7 +339,7 @@ export default defineConfig({
       groupIconVitePlugin(),
       codecovVitePlugin({
         // Put the Codecov vite plugin after all other plugins
-        enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+        enableBundleAnalysis: !isInteractive(), // Works only in CI
         bundleName: 'website',
         uploadToken: process.env.CODECOV_TOKEN,
         gitService: 'github',

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.0",
     "bananass-utils-vitepress": "^0.0.0",
+    "is-interactive": "^2.0.0",
     "markdown-it-footnote": "^4.0.0",
     "vitepress": "^1.6.3",
     "vitepress-plugin-group-icons": "^1.3.6"


### PR DESCRIPTION
This pull request includes changes to the `website/.vitepress/config.mjs` and `website/package.json` files to improve the configuration and dependency management for the project. The most important changes include the addition of the `is-interactive` package and adjustments to the Codecov plugin configuration to work better in CI environments.

Dependency management and configuration improvements:

* [`website/.vitepress/config.mjs`](diffhunk://#diff-bd4ac01d4c35583e9c20414103304b0628a6be199987bd1084fdef61cd43cc71R16): Added import for the `is-interactive` package to the configuration file.
* [`website/.vitepress/config.mjs`](diffhunk://#diff-bd4ac01d4c35583e9c20414103304b0628a6be199987bd1084fdef61cd43cc71L341-R342): Modified the `enableBundleAnalysis` option for the Codecov plugin to use the `isInteractive()` function, ensuring it only runs in CI environments.
* [`website/package.json`](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76R13): Added `is-interactive` as a development dependency.