### PR TITLE
docs(*): delete maintainability badge from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![test](https://github.com/lumirlumir/npm-clang-format-node/actions/workflows/test.yml/badge.svg)](https://github.com/lumirlumir/npm-clang-format-node/actions/workflows/test.yml)
 [![test-cross-platform](https://github.com/lumirlumir/npm-clang-format-node/actions/workflows/test-cross-platform.yml/badge.svg)](https://github.com/lumirlumir/npm-clang-format-node/actions/workflows/test-cross-platform.yml)
 [![codecov](https://codecov.io/gh/lumirlumir/npm-clang-format-node/graph/badge.svg?token=69BF05THA2)](https://codecov.io/gh/lumirlumir/npm-clang-format-node)
-[![Maintainability](https://api.codeclimate.com/v1/badges/4bcedf673457b80b9b18/maintainability)](https://codeclimate.com/github/lumirlumir/npm-clang-format-node/maintainability)
 
 > [!IMPORTANT]
 >


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change removes the Code Climate maintainability badge.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12): Removed the Code Climate maintainability badge.