### PR TITLE
chore(release): bump package versions from `v1.3.2` to `v1.3.3` (`patch`) 

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-clang-format",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "scripts": {
     "formatted:c": "npx clang-format src/formatted.c",
     "formatted:c:dry-run": "npx clang-format -Werror -n src/formatted.c",
@@ -13,6 +13,6 @@
     "unformatted:cpp:dry-run": "npx clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^1.3.2"
+    "clang-format-node": "^1.3.3"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-git-clang-format",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "scripts": {
     "add-a-space-to-line-9-of-main-c-file": "shx cat src/main_overwrite.txt > src/main.c",
     "git-add": "git add src/main.c && git status",
     "git-clang-format": "npx git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.2"
+    "clang-format-git": "^1.3.3"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.3.2"
+  "version": "1.3.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,16 +38,16 @@
     },
     "examples/clang-format": {
       "name": "examples-clang-format",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
-        "clang-format-node": "^1.3.2"
+        "clang-format-node": "^1.3.3"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
-        "clang-format-git": "^1.3.2"
+        "clang-format-git": "^1.3.3"
       }
     },
     "node_modules/@actions/core": {
@@ -17541,21 +17541,6 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -21588,11 +21573,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.3.2",
+        "clang-format-node": "^1.3.3",
         "shx": "^0.4.0"
       },
       "bin": {
@@ -21604,11 +21589,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.3.2",
+        "clang-format-node": "^1.3.3",
         "shx": "^0.4.0"
       },
       "bin": {
@@ -21620,7 +21605,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -21636,20 +21621,20 @@
     },
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
-        "clang-format-git": "^1.3.2",
-        "clang-format-git-python": "^1.3.2",
-        "clang-format-node": "^1.3.2"
+        "clang-format-git": "^1.3.3",
+        "clang-format-git-python": "^1.3.3",
+        "clang-format-node": "^1.3.3"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
-        "clang-format-git": "^1.3.2",
-        "clang-format-git-python": "^1.3.2",
-        "clang-format-node": "^1.3.2"
+        "clang-format-git": "^1.3.3",
+        "clang-format-git-python": "^1.3.3",
+        "clang-format-node": "^1.3.3"
       }
     },
     "tests/integration-binaries-perimission": {
@@ -21662,11 +21647,11 @@
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
-        "clang-format-git": "^1.3.2",
-        "clang-format-git-python": "^1.3.2",
-        "clang-format-node": "^1.3.2"
+        "clang-format-git": "^1.3.3",
+        "clang-format-git-python": "^1.3.3",
+        "clang-format-node": "^1.3.3"
       }
     },
     "tests/integration-cjs": {
@@ -21702,7 +21687,7 @@
       }
     },
     "website": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
         "bananass-utils-vitepress": "^0.0.0",

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -58,7 +58,7 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^1.3.2",
+    "clang-format-node": "^1.3.3",
     "shx": "^0.4.0"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -57,7 +57,7 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^1.3.2",
+    "clang-format-node": "^1.3.3",
     "shx": "^0.4.0"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-cjs",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "commonjs",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.2",
-    "clang-format-git-python": "^1.3.2",
-    "clang-format-node": "^1.3.2"
+    "clang-format-git": "^1.3.3",
+    "clang-format-git-python": "^1.3.3",
+    "clang-format-node": "^1.3.3"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-esm",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.2",
-    "clang-format-git-python": "^1.3.2",
-    "clang-format-node": "^1.3.2"
+    "clang-format-git": "^1.3.3",
+    "clang-format-git-python": "^1.3.3",
+    "clang-format-node": "^1.3.3"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "tests-integration-binaries-permission",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.2",
-    "clang-format-git-python": "^1.3.2",
-    "clang-format-node": "^1.3.2"
+    "clang-format-git": "^1.3.3",
+    "clang-format-git-python": "^1.3.3",
+    "clang-format-node": "^1.3.3"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",


### PR DESCRIPTION
## Release Information: `v1.3.3`

New release of `lumirlumir/npm-clang-format-node` has arrived! :tada:

This PR bumps the package versions from `v1.3.2` to `v1.3.3` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-clang-format-node/actions/runs/14215733817) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-clang-format-node` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | ed550b4       |
| Old Version | `v1.3.2`  |
| New Version | `v1.3.3`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :toolbox: Chores
* chore(sync-server): update `lint-staged.config.js` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/259
* chore(sync-server): update `.editorconfig` `max_line_length` to `100000` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/260
* chore(website): add Codecov Vite plugin and update related configs for bundle analyzing by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/266
* chore(website): conditionally enable bundle analysis in Codecov Vite plugin by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/267
* chore(sync-server): update `.markdownlint.json` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/272
* chore(sync-server): update ESLint config and lint-staged to support markdown linting by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/275
* chore(sync-server): update `FUNDING.yml` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/285
* chore(website): update `package.json` and rename `.mjs` to `.js` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/286
* chore(sync-server): update root level configuration files and fix typos by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/293
* chore(*): update `tsconfig.json` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/296
### :arrows_counterclockwise: Continuous Integrations
* ci(sync-server): add permissions to read contents in `lint.yml` and `test.yml` workflows by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/256
* ci(sync-server): add permissions to `pull-request.yml` and `sync-client.yml` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/257
* ci(*): add read permissions to `test-cross-platform.yml` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/258
* ci(*): update `llvm-build-bump-pr.yml` to add `permissions` and disable `fail-fast` strategy by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/264
* ci(*): update `llvm-build-bump-pr.yml` to enhance permissions and add build provenance attestations by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/265
* ci(*): create `release.yml` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/281
### :memo: Documentation
* docs(*): delete maintainability badge from `README.md` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/287
### :arrow_up: Dependency Updates
* chore(deps-dev): bump typescript from 5.7.3 to 5.8.2 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/252
* chore(deps-dev): bump prettier from 3.5.2 to 3.5.3 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/253
* chore(deps-dev): bump @types/node from 22.13.5 to 22.13.8 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/251
* chore(deps-dev): bump lerna from 8.2.0 to 8.2.1 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/254
* chore(deps-dev): bump @types/node from 22.13.8 to 22.13.9 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/255
* chore(deps-dev): bump @types/node from 22.13.9 to 22.13.10 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/261
* chore(deps-dev): bump eslint from 9.21.0 to 9.22.0 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/262
* chore(deps): bump axios from 1.7.7 to 1.8.2 in the npm_and_yarn group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/263
* chore(deps-dev): bump @babel/core from 7.26.9 to 7.26.10 in the babel group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/268
* chore(deps-dev): bump textlint from 14.4.2 to 14.5.0 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/270
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.3.6 to 1.3.7 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/269
* chore(deps-dev): bump eslint-config-bananass from 0.0.5 to 0.0.6 in the bananass group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/273
* chore(deps-dev): bump lint-staged from 15.4.3 to 15.5.0 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/274
* chore(deps): bump shx from 0.3.4 to 0.4.0 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/276
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.3.7 to 1.3.8 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/282
* chore(deps-dev): bump textlint-rule-allowed-uris from 1.0.8 to 1.0.9 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/283
* chore(deps-dev): bump eslint from 9.22.0 to 9.23.0 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/289
* chore(deps-dev): bump @types/node from 22.13.10 to 22.13.11 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/288
* chore(deps-dev): bump @babel/cli from 7.26.4 to 7.27.0 in the babel group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/291
* chore(deps-dev): bump @types/node from 22.13.11 to 22.13.13 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/290
* chore(deps-dev): bump @types/node from 22.13.13 to 22.13.14 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/292
* chore(deps-dev): bump textlint from 14.5.0 to 14.6.0 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/294
* chore(deps-dev): bump @types/node from 22.13.14 to 22.13.17 by @dependabot in https://github.com/lumirlumir/npm-clang-format-node/pull/295


**Full Changelog**: https://github.com/lumirlumir/npm-clang-format-node/compare/v1.3.2...v1.3.3