### PR TITLE
chore(*): move `FUNDING.yml` files to `.github` repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: [lumirlumir]
-open_collective: lumirlumir

--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -26,8 +26,6 @@ lumirlumir/lumirlumir-configs:
   # ./.github
   - source: ./.github/CODEOWNERS
     dest: ./configs/.github/CODEOWNERS
-  - source: ./.github/FUNDING.yml
-    dest: ./configs/.github/FUNDING.yml
   - source: ./.github/PULL_REQUEST_TEMPLATE.md
     dest: ./configs/.github/PULL_REQUEST_TEMPLATE.md
   - source: ./.github/dependabot.yml


### PR DESCRIPTION
This pull request removes the funding configuration for the `lumirlumir` project and updates the synchronization configuration to stop syncing the removed funding file. These changes are focused on cleaning up unused or outdated configuration files.

Configuration cleanup:

* [`.github/FUNDING.yml`](diffhunk://#diff-07985fdcade0e64d11482724879a644f07879ba61b8fb6c6119e1b1902b72ae4L1-L2): Removed the funding configuration for the `lumirlumir` project, including references to GitHub and Open Collective.
* [`.github/sync-client.yml`](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1L29-L30): Updated the synchronization configuration by removing the entry for syncing the `FUNDING.yml` file.