### PR TITLE
fix(*): update `postinstall` script to remove unnecessary build check

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Set up node_modules
         run: npm ci
 
+      - name: Build
+        run: npm run build --if-present
+
       - name: Build packages
         run: mkdir packs && npm pack --workspace packages --pack-destination packs
 

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -48,7 +48,7 @@
     "provenance": true
   },
   "scripts": {
-    "postinstall": "shx test -d src && npm run build || npm run chmod",
+    "postinstall": "npm run chmod",
     "prepublishOnly": "npm run build",
     "build": "npx babel src -d build && npx tsc && shx cp -r src/script build && shx cp ../../LICENSE.md ../../README.md .",
     "postbuild": "npm run chmod",

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -47,7 +47,7 @@
     "provenance": true
   },
   "scripts": {
-    "postinstall": "shx test -d src && npm run build || npm run chmod",
+    "postinstall": "npm run chmod",
     "prepublishOnly": "npm run build",
     "build": "npx babel src -d build && npx tsc && shx cp -r src/bin build && shx cp ../../LICENSE.md ../../README.md .",
     "postbuild": "npm run chmod",

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -46,7 +46,7 @@
     "provenance": true
   },
   "scripts": {
-    "postinstall": "shx test -d src && npm run build || npm run chmod",
+    "postinstall": "npm run chmod",
     "prepublishOnly": "npm run build",
     "build": "npx babel src -d build && npx tsc && shx cp -r src/bin build && shx cp ../../LICENSE.md ../../README.md .",
     "postbuild": "npm run chmod",


### PR DESCRIPTION
This pull request introduces changes to streamline build processes and simplify post-installation scripts across multiple packages. The most notable updates include adding a build step to the cross-platform workflow and removing conditional checks in post-installation scripts for various packages.

### Workflow improvements:

* [`.github/workflows/test-cross-platform.yml`](diffhunk://#diff-290907d9a4bcf13181105b134bd1645da5a3ef27c54f148ad5823e6b77e88426R44-R46): Added a `Build` step to the workflow to ensure packages are built before testing. (`[.github/workflows/test-cross-platform.ymlR44-R46](diffhunk://#diff-290907d9a4bcf13181105b134bd1645da5a3ef27c54f148ad5823e6b77e88426R44-R46)`)

### Simplification of post-installation scripts:

* [`packages/clang-format-git-python/package.json`](diffhunk://#diff-fb0eb5dba5b2656b3fdea4322c2ed2a691973f2e9ea536ce20b36c347ab1267eL51-R51): Simplified the `postinstall` script by removing the conditional check for the `src` directory and directly running `npm run chmod`. (`[packages/clang-format-git-python/package.jsonL51-R51](diffhunk://#diff-fb0eb5dba5b2656b3fdea4322c2ed2a691973f2e9ea536ce20b36c347ab1267eL51-R51)`)
* [`packages/clang-format-git/package.json`](diffhunk://#diff-d85dcfb0934f579cff896723ab5eeb9a52668d2bb322338dddd93bc1241aa4f1L50-R50): Updated the `postinstall` script to eliminate the conditional directory check, ensuring `npm run chmod` is executed unconditionally. (`[packages/clang-format-git/package.jsonL50-R50](diffhunk://#diff-d85dcfb0934f579cff896723ab5eeb9a52668d2bb322338dddd93bc1241aa4f1L50-R50)`)
* [`packages/clang-format-node/package.json`](diffhunk://#diff-6e04d643c57b851ab02ad78e41531387d2cc01caf6c4cfbaa536aadd37346a30L49-R49): Modified the `postinstall` script to remove the conditional logic and directly invoke `npm run chmod`. (`[packages/clang-format-node/package.jsonL49-R49](diffhunk://#diff-6e04d643c57b851ab02ad78e41531387d2cc01caf6c4cfbaa536aadd37346a30L49-R49)`)