### PR TITLE
chore(release): bump package versions from `v1.3.3` to `v1.3.4` (`patch`)

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-clang-format",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "scripts": {
     "formatted:c": "npx clang-format src/formatted.c",
     "formatted:c:dry-run": "npx clang-format -Werror -n src/formatted.c",
@@ -13,6 +13,6 @@
     "unformatted:cpp:dry-run": "npx clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^1.3.3"
+    "clang-format-node": "^1.3.4"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-git-clang-format",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "scripts": {
     "add-a-space-to-line-9-of-main-c-file": "node -e \"require('fs').copyFileSync('src/main_overwrite.txt','src/main.c')\"",
     "git-add": "git add src/main.c && git status",
     "git-clang-format": "npx git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.3"
+    "clang-format-git": "^1.3.4"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.3.3"
+  "version": "1.3.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,16 +37,16 @@
     },
     "examples/clang-format": {
       "name": "examples-clang-format",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
-        "clang-format-node": "^1.3.3"
+        "clang-format-node": "^1.3.4"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
-        "clang-format-git": "^1.3.3"
+        "clang-format-git": "^1.3.4"
       }
     },
     "node_modules/@actions/core": {
@@ -21474,11 +21474,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.3.3",
+        "clang-format-node": "^1.3.4",
         "shx": "^0.4.0"
       },
       "bin": {
@@ -21490,11 +21490,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.3.3",
+        "clang-format-node": "^1.3.4",
         "shx": "^0.4.0"
       },
       "bin": {
@@ -21506,7 +21506,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -21522,20 +21522,20 @@
     },
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
-        "clang-format-git": "^1.3.3",
-        "clang-format-git-python": "^1.3.3",
-        "clang-format-node": "^1.3.3"
+        "clang-format-git": "^1.3.4",
+        "clang-format-git-python": "^1.3.4",
+        "clang-format-node": "^1.3.4"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
-        "clang-format-git": "^1.3.3",
-        "clang-format-git-python": "^1.3.3",
-        "clang-format-node": "^1.3.3"
+        "clang-format-git": "^1.3.4",
+        "clang-format-git-python": "^1.3.4",
+        "clang-format-node": "^1.3.4"
       }
     },
     "tests/integration-binaries-perimission": {
@@ -21548,11 +21548,11 @@
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
-        "clang-format-git": "^1.3.3",
-        "clang-format-git-python": "^1.3.3",
-        "clang-format-node": "^1.3.3"
+        "clang-format-git": "^1.3.4",
+        "clang-format-git-python": "^1.3.4",
+        "clang-format-node": "^1.3.4"
       }
     },
     "tests/integration-cjs": {
@@ -21588,7 +21588,7 @@
       }
     },
     "website": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
         "markdown-it-footnote": "^4.0.0",

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -58,7 +58,7 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^1.3.3",
+    "clang-format-node": "^1.3.4",
     "shx": "^0.4.0"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -57,7 +57,7 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^1.3.3",
+    "clang-format-node": "^1.3.4",
     "shx": "^0.4.0"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-cjs",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "commonjs",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.3",
-    "clang-format-git-python": "^1.3.3",
-    "clang-format-node": "^1.3.3"
+    "clang-format-git": "^1.3.4",
+    "clang-format-git-python": "^1.3.4",
+    "clang-format-node": "^1.3.4"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-esm",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.3",
-    "clang-format-git-python": "^1.3.3",
-    "clang-format-node": "^1.3.3"
+    "clang-format-git": "^1.3.4",
+    "clang-format-git-python": "^1.3.4",
+    "clang-format-node": "^1.3.4"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "tests-integration-binaries-permission",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^1.3.3",
-    "clang-format-git-python": "^1.3.3",
-    "clang-format-node": "^1.3.3"
+    "clang-format-git": "^1.3.4",
+    "clang-format-git-python": "^1.3.4",
+    "clang-format-node": "^1.3.4"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",


### PR DESCRIPTION
## Release Information: `v1.3.4`

New release of `lumirlumir/npm-clang-format-node` has arrived! :tada:

This PR bumps the package versions from `v1.3.3` to `v1.3.4` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-clang-format-node/actions/runs/16236437387) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-clang-format-node` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 5862509       |
| Old Version | `v1.3.3`  |
| New Version | `v1.3.4`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(*): update `postinstall` script to remove unnecessary build check by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/398
### :toolbox: Chores
* chore(*): update configuration files to use `.cjs` or `.mjs` extensions by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/298
* chore(sync-server): update lint configs and bump package versions by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/310
* chore(sync-server): update `lint-staged` and scripts by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/314
* chore(sync-server): update `dependabot.yml` and `.gitignore` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/326
* chore(sync-server): remove `is-interactive` dependency and update Codecov configuration by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/336
* chore(sync-server): update `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/351
* chore(*): run `npm dedupe` for cleanup by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/362
* chore(*): remove `bananass-utils-vitepress` dependency by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/377
* chore(*): move `FUNDING.yml` files to `.github` repository by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/389
* chore(*): replace `shx` with native Node.js file operations in scripts by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/397
### :arrows_counterclockwise: Continuous Integrations
* ci(*): update actions to use docker native action by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/393
* ci(*): update `test-cross-platform.yml` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/396
### :art: Styles
* style(*): clean up comments and remove unnecessary whitespace in multiple files by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/380
### :test_tube: Tests
* test(*): simplify describe blocks in test files by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/331
### :arrow_up: Dependency Updates
* chore(deps-dev): bump @types/node from 22.13.17 to 22.14.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/299
* chore(deps-dev): bump eslint-config-bananass from 0.0.6 to 0.0.7 in the bananass group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/300
* chore(deps-dev): bump eslint from 9.23.0 to 9.24.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/301
* chore(deps-dev): bump typescript from 5.8.2 to 5.8.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/302
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.3.8 to 1.4.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/303
* chore(deps-dev): bump lerna from 8.2.1 to 8.2.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/305
* chore(deps-dev): bump @types/node from 22.14.0 to 22.14.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/306
* chore(deps-dev): bump textlint-rule-allowed-uris from 1.0.9 to 1.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/308
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.4.1 to 1.5.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/307
* chore(deps-dev): bump lint-staged from 15.5.0 to 15.5.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/311
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.5.1 to 1.5.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/312
* chore(deps-dev): bump eslint from 9.24.0 to 9.25.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/315
* chore(deps-dev): bump eslint from 9.25.0 to 9.25.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/316
* chore(deps-dev): bump @types/node from 22.14.1 to 22.15.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/318
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/317
* chore(deps-dev): bump @types/node from 22.15.0 to 22.15.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/320
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/319
* chore(deps-dev): bump @types/node from 22.15.2 to 22.15.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/321
* chore(deps-dev): bump the babel group across 1 directory with 3 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/322
* chore(deps-dev): bump textlint from 14.6.0 to 14.7.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/323
* chore(deps-dev): bump eslint from 9.25.1 to 9.26.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/324
* chore(deps-dev): bump @types/node from 22.15.3 to 22.15.9 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/325
* chore(deps-dev): bump the babel group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/327
* chore(deps-dev): bump lint-staged from 15.5.1 to 15.5.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/328
* chore(deps-dev): bump @types/node from 22.15.9 to 22.15.15 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/330
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/332
* chore(deps-dev): bump @types/node from 22.15.16 to 22.15.17 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/333
* chore(deps-dev): bump lint-staged from 15.5.2 to 16.0.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/334
* chore(deps-dev): bump the bananass group across 2 directories with 3 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/335
* chore(deps): bump undici from 6.21.1 to 6.21.3 in the npm_and_yarn group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/340
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.5.2 to 1.5.5 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/341
* chore(deps-dev): bump @types/node from 22.15.17 to 22.15.18 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/338
* chore(deps-dev): bump eslint from 9.26.0 to 9.27.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/345
* chore(deps-dev): bump markdownlint-cli from 0.44.0 to 0.45.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/344
* chore(deps-dev): bump @codecov/vite-plugin from 1.9.0 to 1.9.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/346
* chore(deps-dev): bump the bananass group across 2 directories with 3 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/348
* chore(deps-dev): bump @types/node from 22.15.18 to 22.15.21 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/350
* chore(deps-dev): bump textlint from 14.7.1 to 14.7.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/349
* chore(deps-dev): bump @types/node from 22.15.21 to 22.15.24 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/354
* chore(deps-dev): bump @babel/core from 7.27.1 to 7.27.3 in the babel group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/352
* chore(deps-dev): bump @types/node from 22.15.24 to 22.15.26 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/355
* chore(deps-dev): bump lint-staged from 16.0.0 to 16.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/356
* chore(deps-dev): bump eslint from 9.27.0 to 9.28.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/358
* chore(deps-dev): bump @babel/core from 7.27.3 to 7.27.4 in the babel group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/357
* chore(deps-dev): bump @types/node from 22.15.26 to 22.15.29 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/359
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.5.5 to 1.6.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/360
* chore(deps-dev): bump the bananass group across 2 directories with 3 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/364
* chore(deps-dev): bump textlint-rule-allowed-uris from 1.1.0 to 1.1.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/366
* chore(deps-dev): bump @types/node from 22.15.29 to 24.0.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/367
* chore(deps-dev): bump @types/node from 24.0.0 to 24.0.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/368
* chore(deps-dev): bump eslint from 9.28.0 to 9.29.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/370
* chore(deps-dev): bump lint-staged from 16.1.0 to 16.1.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/369
* chore(deps-dev): bump @types/node from 24.0.1 to 24.0.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/371
* chore(deps-dev): bump concurrently from 9.1.2 to 9.2.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/372
* chore(deps-dev): bump prettier from 3.5.3 to 3.6.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/373
* chore(deps-dev): bump @babel/core from 7.27.4 to 7.27.7 in the babel group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/376
* chore(deps-dev): bump prettier from 3.6.0 to 3.6.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/378
* chore(deps-dev): bump eslint from 9.29.0 to 9.30.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/382
* chore(deps-dev): bump lerna from 8.2.2 to 8.2.3 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/381
* chore(deps-dev): bump vitepress-plugin-group-icons from 1.6.0 to 1.6.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/383
* chore(deps-dev): bump @types/node from 24.0.3 to 24.0.8 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/385
* chore(deps-dev): bump @types/node from 24.0.8 to 24.0.10 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/387
* chore(deps-dev): bump eslint from 9.30.0 to 9.30.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/386
* chore(deps-dev): bump the babel group across 1 directory with 3 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/388
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/391


**Full Changelog**: https://github.com/lumirlumir/npm-clang-format-node/compare/v1.3.3...v1.3.4