### PR TITLE
build(*): add `cp.mjs` script for file copying and update build scripts

### DIFF
--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -41,6 +41,8 @@ lumirlumir/lumirlumir-configs:
   - source: ./.vscode/settings.json
     dest: ./configs/.vscode/settings.json
   # ./scripts
+  - source: ./scripts/cp.mjs
+    dest: ./configs/scripts/cp.mjs
   - source: ./scripts/vercel-ignore-command.sh
     dest: ./configs/scripts/vercel-ignore-command.sh
   # ./

--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -169,8 +169,8 @@ jobs:
         run: |
           docker exec ${{ matrix.docker.node-name }} /bin/bash -c "
             echo ---Set up dependencies--- &&
-            apt update -y &&
-            apt install -y git &&
+            apt-get update -y &&
+            apt-get install -y git &&
 
             echo ---Debug uname -m--- &&
             uname -m &&

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "postinstall": "npm run chmod",
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build && npx tsc && shx cp -r src/script build && shx cp ../../LICENSE.md ../../README.md .",
+    "build": "npx babel src -d build && npx tsc && node ../../scripts/cp.mjs src/script build/script ../../LICENSE.md LICENSE.md ../../README.md README.md",
     "postbuild": "npm run chmod",
     "test": "node --test",
     "chmod": "shx chmod 755 ./src/script/**/* ./build/script/**/* || exit 0",

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "postinstall": "npm run chmod",
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build && npx tsc && shx cp -r src/bin build && shx cp ../../LICENSE.md ../../README.md .",
+    "build": "npx babel src -d build && npx tsc && node ../../scripts/cp.mjs src/bin build/bin ../../LICENSE.md LICENSE.md ../../README.md README.md",
     "postbuild": "npm run chmod",
     "test": "node --test",
     "chmod": "shx chmod 755 ./src/bin/**/* ./build/bin/**/* || exit 0",

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "postinstall": "npm run chmod",
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build && npx tsc && shx cp -r src/bin build && shx cp ../../LICENSE.md ../../README.md .",
+    "build": "npx babel src -d build && npx tsc && node ../../scripts/cp.mjs src/bin build/bin ../../LICENSE.md LICENSE.md ../../README.md README.md",
     "postbuild": "npm run chmod",
     "test": "node --test",
     "chmod": "shx chmod 755 ./src/bin/**/* ./build/bin/**/* || exit 0",

--- a/scripts/cp.mjs
+++ b/scripts/cp.mjs
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview Script to copy files from src to dest.
+ * Usage: `node path/to/cp.mjs src1 dest1 src2 dest2 src3 dest3 ...`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { cpSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// --------------------------------------------------------------------------------
+// Copy Files
+// --------------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+
+for (let i = 0; i < args.length; i += 2) {
+  cpSync(resolve(process.cwd(), args[i]), resolve(process.cwd(), args[i + 1]), {
+    force: true,
+    recursive: true,
+  });
+}

--- a/website/docs/further-reading/build-process.md
+++ b/website/docs/further-reading/build-process.md
@@ -9,8 +9,8 @@ description: "Guide for building the `clang-format` native binary on Linux and c
 You can build `clang-format` native binary on Linux using the script below.
 
 ```sh
-sudo apt update -y
-sudo apt install -y git python3 g++ cmake ninja-build
+sudo apt-get update -y
+sudo apt-get install -y git python3 g++ cmake ninja-build
 
 # Replace llvmorg-18.1.8 with your desired version. Check the tags at https://github.com/llvm/llvm-project/tags
 git clone --depth 1 --branch llvmorg-18.1.8 https://github.com/llvm/llvm-project.git


### PR DESCRIPTION
This pull request introduces updates to streamline file copying processes across multiple packages, refactor scripts for consistency, and improve documentation. The most significant changes involve the addition of a reusable file copy script (`cp.mjs`), updates to package build commands to use this script, and the replacement of `apt` commands with `apt-get` for better compatibility.

### File Copying Enhancements:
* Added a new script `scripts/cp.mjs` to facilitate file copying with support for recursive and forced operations. This script is now reusable across packages.
* Updated `build` scripts in `packages/clang-format-git-python/package.json`, `packages/clang-format-git/package.json`, and `packages/clang-format-node/package.json` to replace `shx cp` commands with `node ../../scripts/cp.mjs`, enhancing consistency and maintainability. [[1]](diffhunk://#diff-fb0eb5dba5b2656b3fdea4322c2ed2a691973f2e9ea536ce20b36c347ab1267eL53-R53) [[2]](diffhunk://#diff-d85dcfb0934f579cff896723ab5eeb9a52668d2bb322338dddd93bc1241aa4f1L52-R52) [[3]](diffhunk://#diff-6e04d643c57b851ab02ad78e41531387d2cc01caf6c4cfbaa536aadd37346a30L51-R51)

### Configuration Updates:
* Added `cp.mjs` to `.github/sync-client.yml` for syncing scripts across repositories.

### Compatibility Improvements:
* Replaced `apt` commands with `apt-get` in `.github/workflows/test-cross-platform.yml` and `website/docs/further-reading/build-process.md` for improved compatibility and standardization. [[1]](diffhunk://#diff-290907d9a4bcf13181105b134bd1645da5a3ef27c54f148ad5823e6b77e88426L172-R173) [[2]](diffhunk://#diff-edab0f47c80e77f546d2197d14eaba72fd8253dfe4cae3ff34f13f80c229a394L12-R13)