### PR TITLE
chore(*): enable strict type checking options in `tsconfig`

### DIFF
--- a/packages/clang-format-git-python/tsconfig.json
+++ b/packages/clang-format-git-python/tsconfig.json
@@ -15,7 +15,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "alwaysStrict": true,
-    "exactOptionalPropertyTypes": false, // Off: TODO
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitOverride": true,
@@ -25,12 +25,12 @@
     "noUncheckedIndexedAccess": false, // Off: Too tight
     "noUnusedLocals": false, // Off: Does not recognize JSDoc `@import` statements
     "noUnusedParameters": true,
-    "strict": false, // Off: TODO
+    "strict": true,
     "strictBindCallApply": true,
     "strictBuiltinIteratorReturn": true,
     "strictFunctionTypes": true,
-    "strictNullChecks": false, // Off: TODO
-    "strictPropertyInitialization": false, // Off: TODO
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "useUnknownInCatchVariables": true,
 
     /* Modules */

--- a/packages/clang-format-git/tsconfig.json
+++ b/packages/clang-format-git/tsconfig.json
@@ -15,7 +15,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "alwaysStrict": true,
-    "exactOptionalPropertyTypes": false, // Off: TODO
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitOverride": true,
@@ -25,12 +25,12 @@
     "noUncheckedIndexedAccess": false, // Off: Too tight
     "noUnusedLocals": false, // Off: Does not recognize JSDoc `@import` statements
     "noUnusedParameters": true,
-    "strict": false, // Off: TODO
+    "strict": true,
     "strictBindCallApply": true,
     "strictBuiltinIteratorReturn": true,
     "strictFunctionTypes": true,
-    "strictNullChecks": false, // Off: TODO
-    "strictPropertyInitialization": false, // Off: TODO
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "useUnknownInCatchVariables": true,
 
     /* Modules */

--- a/packages/clang-format-node/tsconfig.json
+++ b/packages/clang-format-node/tsconfig.json
@@ -15,7 +15,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "alwaysStrict": true,
-    "exactOptionalPropertyTypes": false, // Off: TODO
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitOverride": true,
@@ -25,12 +25,12 @@
     "noUncheckedIndexedAccess": false, // Off: Too tight
     "noUnusedLocals": false, // Off: Does not recognize JSDoc `@import` statements
     "noUnusedParameters": true,
-    "strict": false, // Off: TODO
+    "strict": true,
     "strictBindCallApply": true,
     "strictBuiltinIteratorReturn": true,
     "strictFunctionTypes": true,
-    "strictNullChecks": false, // Off: TODO
-    "strictPropertyInitialization": false, // Off: TODO
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "useUnknownInCatchVariables": true,
 
     /* Modules */


### PR DESCRIPTION
This pull request tightens TypeScript compiler settings across the `clang-format-git-python`, `clang-format-git`, and `clang-format-node` packages. The main focus is enabling stricter type checking and initialization rules to improve code safety and reliability.

TypeScript configuration improvements:

* Enabled `strict` mode, `strictNullChecks`, and `strictPropertyInitialization` in `tsconfig.json` for all three packages to enforce stricter type safety and initialization checks.
* Set `exactOptionalPropertyTypes` to `true` in all affected `tsconfig.json` files, ensuring more precise handling of optional properties.