### PR TITLE
docs(*): update documentation to reflect the latest v2.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Node wrapper for LLVM Clang's `clang-format` and `git-clang-format` native binar
 
 For full documentation, see the [official documentation of the `clang-format-node`](https://clang-format-node.lumir.page).
 
+## Fully Secure Binaries
+
+Binaries are built directly from the [official LLVM project source code](https://github.com/llvm/llvm-project). No third-party binaries are used; everything is built from scratch using [GitHub Actions](https://github.com/lumirlumir/npm-clang-format-node/blob/main/.github/workflows/llvm-build-bump-pr.yml).
+
+All binaries are fully verified by [GitHub Actions Attestation Provenances](https://github.com/lumirlumir/npm-clang-format-node/attestations) and [npm Build Provenances](https://docs.npmjs.com/generating-provenance-statements).
+
+For more information, please refer to the [Security](https://github.com/lumirlumir/npm-clang-format-node/blob/main/SECURITY.md) page.
+
 ## Included Packages
 
 This repository is maintained as a **monorepo** and includes the following **three** packages.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,12 +6,16 @@ Some may have concerns about the security of binary files, but the following poi
 
 1. First and foremost, we have no intention of harming anyone's project.
 
-1. Second, our build processes are fully transparent. You can review exactly how these binaries are built and track the pull requests showing their origins.
+1. Binaries are built directly from the [official LLVM project source code](https://github.com/llvm/llvm-project). No third-party binaries are used; everything is built from scratch using [GitHub Actions](https://github.com/lumirlumir/npm-clang-format-node/blob/main/.github/workflows/llvm-build-bump-pr.yml).
+
+1. Our build processes are fully transparent. You can review exactly how these binaries are built and track the pull requests showing their origins.
 
     - See [`llvm-build-bump-pr.yml`](https://github.com/lumirlumir/npm-clang-format-node/blob/main/.github/workflows/llvm-build-bump-pr.yml).
-    - See the [Pull Request list on GitHub](https://github.com/lumirlumir/npm-clang-format-node/pulls?q=is%3Apr+%28deps%29%3A+bump+LLVM+from+label%3Adependencies).
+    - See the [Pull Request list on GitHub](https://github.com/lumirlumir/npm-clang-format-node/pulls?q=is%3Apr+%28deps%29%3A+%22bump+LLVM+from%22+label%3Adependencies+).
 
-1. Third, when you run the command `clang-format --version`, you can verify the current **LLVM version**, **repository URL**, and **commit SHA**, as shown below:
+1. All binaries are fully verified by [GitHub Actions Attestation Provenances](https://github.com/lumirlumir/npm-clang-format-node/attestations) and [npm Build Provenances](https://docs.npmjs.com/generating-provenance-statements).
+
+1. When you run the command `clang-format --version`, you can verify the current **LLVM version**, **repository URL**, and **commit SHA**, as shown below:
 
     ```sh
     clang-format version 18.1.8 (https://github.com/llvm/llvm-project 3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff)

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -199,6 +199,10 @@ export default defineConfig({
               link: 'cli',
             },
             {
+              text: 'Security',
+              link: 'security',
+            },
+            {
               text: 'Supported',
               link: 'supported',
             },

--- a/website/docs/get-started/security.md
+++ b/website/docs/get-started/security.md
@@ -1,0 +1,3 @@
+# Security
+
+For more information, please refer to the [Security](/docs/community/security) page.

--- a/website/docs/get-started/supported.md
+++ b/website/docs/get-started/supported.md
@@ -74,13 +74,13 @@ We used the following Images to build `clang-format` excuatable binaries.
 >
 > If you want to see which software is included in **GitHub Actions runner**, click [here](https://github.com/actions/runner-images?tab=readme-ov-file#available-images) and refer to the 'Included Software' column.
 
-Binary Folder Name | Docker(Build) Image                                                |
------------------- | ------------------------------------------------------------------ |
-`darwin-arm64`     | GitHub Actions runner `macos-14`                                   |
-`darwin-x64`       | GitHub Actions runner `macos-13`                                   |
-`linux-arm`        | [`arm32v7/ubuntu:22.04`](https://hub.docker.com/r/arm32v7/ubuntu/) |
-`linux-arm64`      | [`arm64v8/ubuntu:22.04`](https://hub.docker.com/r/arm64v8/ubuntu/) |
-`linux-ppc64`      | [`ppc64le/ubuntu:22.04`](https://hub.docker.com/r/ppc64le/ubuntu/) |
-`linux-s390x`      | [`s390x/ubuntu:22.04`](https://hub.docker.com/r/s390x/ubuntu/)     |
-`linux-x64`        | GitHub Actions runner `ubuntu-22.04`                               |
-`win32-x64`        | GitHub Actions runner `windows-2022`                               |
+Binary Folder Name | Docker **Build** Image                                             | Docker **Test** Image                                              |
+------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
+`darwin-arm64`     | GitHub Actions runner `macos-14`                                   | GitHub Actions runner `macos-14`                                   |
+`darwin-x64`       | GitHub Actions runner `macos-13`                                   | GitHub Actions runner `macos-13`                                   |
+`linux-arm`        | [`python:3.10.18-bullseye`](https://hub.docker.com/_/python)       | [`arm32v7/ubuntu:22.04`](https://hub.docker.com/r/arm32v7/ubuntu/) |
+`linux-arm64`      | [`python:3.10.18-bullseye`](https://hub.docker.com/_/python)       | [`arm64v8/ubuntu:22.04`](https://hub.docker.com/r/arm64v8/ubuntu/) |
+`linux-ppc64`      | [`buildpack-deps:jammy`](https://hub.docker.com/_/buildpack-deps/) | [`ppc64le/ubuntu:22.04`](https://hub.docker.com/r/ppc64le/ubuntu/) |
+`linux-s390x`      | [`buildpack-deps:jammy`](https://hub.docker.com/_/buildpack-deps/) | [`s390x/ubuntu:22.04`](https://hub.docker.com/r/s390x/ubuntu/)     |
+`linux-x64`        | GitHub Actions runner `ubuntu-22.04`                               | GitHub Actions runner `ubuntu-22.04`                               |
+`win32-x64`        | GitHub Actions runner `windows-2022`                               | GitHub Actions runner `windows-2022`                               |

--- a/website/index.md
+++ b/website/index.md
@@ -25,17 +25,24 @@ hero:
       link: https://github.com/lumirlumir/npm-clang-format-node
 
 features:
-  - icon: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" height="32px" width="32px" xmlns="http://www.w3.org/2000/svg"><path d="M185.7 268.1h76.2l-38.1-91.6-38.1 91.6zM223.8 32L16 106.4l31.8 275.7 176 97.9 176-97.9 31.8-275.7zM354 373.8h-48.6l-26.2-65.4H168.6l-26.2 65.4H93.7L223.8 81.5z"></path></svg>'
-    title: Drop-in replacement for 'angular/clang-format'
-    details: Switch from 'angular/clang-format' to <code>clang-format-node</code> in no time.
-    link: /docs/get-started/migration-from-angular-clang-format
-    linkText: Migration Guide
+  - icon: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="32px" width="32px" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-width="2" d="M19,9.9999 L19,1.9999 L7,1.9999 L7,13.9999 L14,13.9999 L14,6.9999 L2,6.9999 L2,18.9999 L10,18.9999 M14,23 L20,17 M21,14 C19.8954305,14 19,14.8954305 19,16 C19,17.1045695 19.8954305,18 21,18 C22.1045695,18 23,17.1045695 23,16"></path></svg>'
+    title: Fully Secure Binaries
+    details: Built directly from the official LLVM project source code. Fully verified by GitHub Actions Attestation Provenances and npm Build Provenances.
+    link: /docs/community/security
+    linkText: Security
+    rel: external
 
   - icon: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" height="32px" width="32px" xmlns="http://www.w3.org/2000/svg"><path d="M224 508c-6.7 0-13.5-1.8-19.4-5.2l-61.7-36.5c-9.2-5.2-4.7-7-1.7-8 12.3-4.3 14.8-5.2 27.9-12.7 1.4-.8 3.2-.5 4.6.4l47.4 28.1c1.7 1 4.1 1 5.7 0l184.7-106.6c1.7-1 2.8-3 2.8-5V149.3c0-2.1-1.1-4-2.9-5.1L226.8 37.7c-1.7-1-4-1-5.7 0L36.6 144.3c-1.8 1-2.9 3-2.9 5.1v213.1c0 2 1.1 4 2.9 4.9l50.6 29.2c27.5 13.7 44.3-2.4 44.3-18.7V167.5c0-3 2.4-5.3 5.4-5.3h23.4c2.9 0 5.4 2.3 5.4 5.3V378c0 36.6-20 57.6-54.7 57.6-10.7 0-19.1 0-42.5-11.6l-48.4-27.9C8.1 389.2.7 376.3.7 362.4V149.3c0-13.8 7.4-26.8 19.4-33.7L204.6 9c11.7-6.6 27.2-6.6 38.8 0l184.7 106.7c12 6.9 19.4 19.8 19.4 33.7v213.1c0 13.8-7.4 26.7-19.4 33.7L243.4 502.8c-5.9 3.4-12.6 5.2-19.4 5.2zm149.1-210.1c0-39.9-27-50.5-83.7-58-57.4-7.6-63.2-11.5-63.2-24.9 0-11.1 4.9-25.9 47.4-25.9 37.9 0 51.9 8.2 57.7 33.8.5 2.4 2.7 4.2 5.2 4.2h24c1.5 0 2.9-.6 3.9-1.7s1.5-2.6 1.4-4.1c-3.7-44.1-33-64.6-92.2-64.6-52.7 0-84.1 22.2-84.1 59.5 0 40.4 31.3 51.6 81.8 56.6 60.5 5.9 65.2 14.8 65.2 26.7 0 20.6-16.6 29.4-55.5 29.4-48.9 0-59.6-12.3-63.2-36.6-.4-2.6-2.6-4.5-5.3-4.5h-23.9c-3 0-5.3 2.4-5.3 5.3 0 31.1 16.9 68.2 97.8 68.2 58.4-.1 92-23.2 92-63.4z"></path></svg>'
     title: Zero dependencies
     details: No need for Python, C++, or any npm sub-dependencies. Just use Node.js alone, with no extra dependencies.
     link: /docs/get-started/installation
     linkText: Installation
+
+  - icon: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" height="32px" width="32px" xmlns="http://www.w3.org/2000/svg"><path d="M185.7 268.1h76.2l-38.1-91.6-38.1 91.6zM223.8 32L16 106.4l31.8 275.7 176 97.9 176-97.9 31.8-275.7zM354 373.8h-48.6l-26.2-65.4H168.6l-26.2 65.4H93.7L223.8 81.5z"></path></svg>'
+    title: Drop-in replacement for 'angular/clang-format'
+    details: Switch from 'angular/clang-format' to <code>clang-format-node</code> in no time.
+    link: /docs/get-started/migration-from-angular-clang-format
+    linkText: Migration Guide
 
   - icon: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="32px" width="32px" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.486 2 2 6.486 2 12v4.143C2 17.167 2.897 18 4 18h1a1 1 0 0 0 1-1v-5.143a1 1 0 0 0-1-1h-.908C4.648 6.987 7.978 4 12 4s7.352 2.987 7.908 6.857H19a1 1 0 0 0-1 1V18c0 1.103-.897 2-2 2h-2v-1h-4v3h6c2.206 0 4-1.794 4-4 1.103 0 2-.833 2-1.857V12c0-5.514-4.486-10-10-10z"></path></svg>'
     title: Wide range of support
@@ -54,13 +61,6 @@ features:
     details: Each package releases a new npm version with every clang-format update. GitHub Actions automatically checks for updates, builds the packages, and creates a pull request.
     link: https://github.com/lumirlumir/npm-clang-format-node/blob/main/.github/workflows/llvm-build-bump-pr.yml
     linkText: GitHub Actions
-    rel: external
-
-  - icon: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="32px" width="32px" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-width="2" d="M19,9.9999 L19,1.9999 L7,1.9999 L7,13.9999 L14,13.9999 L14,6.9999 L2,6.9999 L2,18.9999 L10,18.9999 M14,23 L20,17 M21,14 C19.8954305,14 19,14.8954305 19,16 C19,17.1045695 19.8954305,18 21,18 C22.1045695,18 23,17.1045695 23,16"></path></svg>'
-    title: Continuous maintenance
-    details: LuMir, the author, is deeply passionate about open source. Maintenance never stops.
-    link: https://github.com/lumirlumir
-    linkText: Who is LuMir?
     rel: external
 
   - title: 📦<code>clang-format-node</code>


### PR DESCRIPTION
This pull request introduces significant improvements to the project's documentation and website, focusing on transparency and assurance regarding binary security. The most important changes clarify that all distributed binaries are built directly from official LLVM source code, are fully verified, and provide users with easy access to security information. Additionally, the website and documentation have been updated to highlight these security guarantees and improve clarity around build environments.

**Security and provenance documentation:**

* Added a new "Fully Secure Binaries" section to `README.md` explaining that binaries are built from official LLVM sources, verified by GitHub Actions Attestation Provenances and npm Build Provenances, and linking to the dedicated security page.
* Improved `SECURITY.md` to explicitly state that no third-party binaries are used, and added details about provenance verification and transparency of the build process.
* Added a new security page to the website documentation (`website/docs/get-started/security.md`) and linked it from relevant sections.

**Website navigation and feature highlights:**

* Updated the website navigation (`website/.vitepress/config.js`) to include a direct link to the new Security page.
* Revised the homepage features (`website/index.md`) to prominently feature "Fully Secure Binaries" and move the "Drop-in replacement for 'angular/clang-format'" section further down. The "Continuous maintenance" feature was removed for clarity. [[1]](diffhunk://#diff-faed261a0db87cb403b9bb172bc51fd1e6f1071956fc7e86f33030b8a31dee82L28-R46) [[2]](diffhunk://#diff-faed261a0db87cb403b9bb172bc51fd1e6f1071956fc7e86f33030b8a31dee82L59-L65)

**Build environment documentation:**

* Updated the supported build images table in `website/docs/get-started/supported.md` to clearly differentiate between Docker build and test images for each platform, improving transparency about the build environments.