### PR TITLE
chore(release): bump package versions from `v2.0.0` to `v2.0.1` (`patch`)

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "examples-clang-format",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "formatted:c": "npx clang-format src/formatted.c",
     "formatted:c:dry-run": "npx clang-format -Werror -n src/formatted.c",
@@ -13,6 +13,6 @@
     "unformatted:cpp:dry-run": "npx clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^2.0.0"
+    "clang-format-node": "^2.0.1"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "examples-git-clang-format",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "add-a-space-to-line-9-of-main-c-file": "node -e \"require('fs').copyFileSync('src/main_overwrite.txt','src/main.c')\"",
     "git-add": "git add src/main.c && git status",
     "git-clang-format": "npx git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^2.0.0"
+    "clang-format-git": "^2.0.1"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "2.0.0"
+  "version": "2.0.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,16 +37,16 @@
     },
     "examples/clang-format": {
       "name": "examples-clang-format",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "clang-format-node": "^2.0.0"
+        "clang-format-node": "^2.0.1"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "clang-format-git": "^2.0.0"
+        "clang-format-git": "^2.0.1"
       }
     },
     "node_modules/@actions/core": {
@@ -20973,11 +20973,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^2.0.0"
+        "clang-format-node": "^2.0.1"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -20988,11 +20988,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^2.0.0"
+        "clang-format-node": "^2.0.1"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -21003,7 +21003,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -21016,20 +21016,20 @@
     },
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "clang-format-git": "^2.0.0",
-        "clang-format-git-python": "^2.0.0",
-        "clang-format-node": "^2.0.0"
+        "clang-format-git": "^2.0.1",
+        "clang-format-git-python": "^2.0.1",
+        "clang-format-node": "^2.0.1"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "clang-format-git": "^2.0.0",
-        "clang-format-git-python": "^2.0.0",
-        "clang-format-node": "^2.0.0"
+        "clang-format-git": "^2.0.1",
+        "clang-format-git-python": "^2.0.1",
+        "clang-format-node": "^2.0.1"
       }
     },
     "tests/integration-binaries-perimission": {
@@ -21042,11 +21042,11 @@
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "clang-format-git": "^2.0.0",
-        "clang-format-git-python": "^2.0.0",
-        "clang-format-node": "^2.0.0"
+        "clang-format-git": "^2.0.1",
+        "clang-format-git-python": "^2.0.1",
+        "clang-format-node": "^2.0.1"
       }
     },
     "tests/integration-cjs": {
@@ -21082,7 +21082,7 @@
       }
     },
     "website": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.1",
         "markdown-it-footnote": "^4.0.0",

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -58,6 +58,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^2.0.0"
+    "clang-format-node": "^2.0.1"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -57,6 +57,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^2.0.0"
+    "clang-format-node": "^2.0.1"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-cjs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "commonjs",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^2.0.0",
-    "clang-format-git-python": "^2.0.0",
-    "clang-format-node": "^2.0.0"
+    "clang-format-git": "^2.0.1",
+    "clang-format-git-python": "^2.0.1",
+    "clang-format-node": "^2.0.1"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "tests-integration-api-esm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^2.0.0",
-    "clang-format-git-python": "^2.0.0",
-    "clang-format-node": "^2.0.0"
+    "clang-format-git": "^2.0.1",
+    "clang-format-git-python": "^2.0.1",
+    "clang-format-node": "^2.0.1"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "tests-integration-binaries-permission",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^2.0.0",
-    "clang-format-git-python": "^2.0.0",
-    "clang-format-node": "^2.0.0"
+    "clang-format-git": "^2.0.1",
+    "clang-format-git-python": "^2.0.1",
+    "clang-format-node": "^2.0.1"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "website",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "dev": "npx vitepress --open --host",


### PR DESCRIPTION
## Release Information: `v2.0.1`

New release of `lumirlumir/npm-clang-format-node` has arrived! :tada:

This PR bumps the package versions from `v2.0.0` to `v2.0.1` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-clang-format-node/actions/runs/18087557012) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-clang-format-node` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 66cee04       |
| Old Version | `v2.0.0`  |
| New Version | `v2.0.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :toolbox: Chores
* chore(sync-server): add `cooldown` option to `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/465
* chore(sync-server): update `.vscode/settings.json` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/466
### :arrow_up: Dependency Updates
* chore(deps-dev): bump @types/node from 24.4.0 to 24.5.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/462
* chore(deps-dev): bump @types/node from 24.5.0 to 24.5.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/464
* chore(deps): bump LLVM from llvmorg-21.1.1 to llvmorg-21.1.2 by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/467


**Full Changelog**: https://github.com/lumirlumir/npm-clang-format-node/compare/v2.0.0...v2.0.1