### PR TITLE
chore(release): bump package versions from `v3.0.1` to `v3.0.2` (`patch`)

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -12,6 +12,6 @@
     "unformatted:cpp:dry-run": "npx clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.1"
+    "clang-format-node": "^3.0.2"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -7,6 +7,6 @@
     "git-clang-format": "npx git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.1"
+    "clang-format-git": "^3.0.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-clang-format-node",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-clang-format-node",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "workspaces": [
         "examples/*",
         "packages/*",
@@ -34,13 +34,13 @@
     "examples/clang-format": {
       "name": "examples-clang-format",
       "dependencies": {
-        "clang-format-node": "^3.0.1"
+        "clang-format-node": "^3.0.2"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
       "dependencies": {
-        "clang-format-git": "^3.0.1"
+        "clang-format-git": "^3.0.2"
       }
     },
     "node_modules/@actions/core": {
@@ -10066,11 +10066,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.1"
+        "clang-format-node": "^3.0.2"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -10084,11 +10084,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.1"
+        "clang-format-node": "^3.0.2"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -10102,7 +10102,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -10119,25 +10119,25 @@
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
       "dependencies": {
-        "clang-format-git": "^3.0.1",
-        "clang-format-git-python": "^3.0.1",
-        "clang-format-node": "^3.0.1"
+        "clang-format-git": "^3.0.2",
+        "clang-format-git-python": "^3.0.2",
+        "clang-format-node": "^3.0.2"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
       "dependencies": {
-        "clang-format-git": "^3.0.1",
-        "clang-format-git-python": "^3.0.1",
-        "clang-format-node": "^3.0.1"
+        "clang-format-git": "^3.0.2",
+        "clang-format-git-python": "^3.0.2",
+        "clang-format-node": "^3.0.2"
       }
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
       "dependencies": {
-        "clang-format-git": "^3.0.1",
-        "clang-format-git-python": "^3.0.1",
-        "clang-format-node": "^3.0.1"
+        "clang-format-git": "^3.0.2",
+        "clang-format-git-python": "^3.0.2",
+        "clang-format-node": "^3.0.2"
       }
     },
     "website": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-clang-format-node",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "packageManager": "npm@11.11.0",
   "engines": {
     "node": ">=20.19.6"

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -59,6 +59,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.1"
+    "clang-format-node": "^3.0.2"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -58,6 +58,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.1"
+    "clang-format-node": "^3.0.2"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.1",
-    "clang-format-git-python": "^3.0.1",
-    "clang-format-node": "^3.0.1"
+    "clang-format-git": "^3.0.2",
+    "clang-format-git-python": "^3.0.2",
+    "clang-format-node": "^3.0.2"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.1",
-    "clang-format-git-python": "^3.0.1",
-    "clang-format-node": "^3.0.1"
+    "clang-format-git": "^3.0.2",
+    "clang-format-git-python": "^3.0.2",
+    "clang-format-node": "^3.0.2"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -5,8 +5,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.1",
-    "clang-format-git-python": "^3.0.1",
-    "clang-format-node": "^3.0.1"
+    "clang-format-git": "^3.0.2",
+    "clang-format-git-python": "^3.0.2",
+    "clang-format-node": "^3.0.2"
   }
 }


### PR DESCRIPTION
## Release Information: `v3.0.2`

New release of `lumirlumir/npm-clang-format-node` has arrived! :tada:

This PR bumps the package versions from `v3.0.1` to `v3.0.2` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-clang-format-node/actions/runs/24328622488) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-clang-format-node` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | a3fa91b       |
| Old Version | `v3.0.1`  |
| New Version | `v3.0.2`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(deps): bump LLVM from llvmorg-22.1.2 to llvmorg-22.1.3 by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/607
### :toolbox: Chores
* chore(sync-server): update `codecov/codecov-action` to v6, `dependabot.yml`, and `.gitignore` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/599
* chore(sync-server): update ignore files by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/601
* chore(*): use TypeScript v6 by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/603
### :arrows_counterclockwise: Continuous Integrations
* ci(sync-server): reestablish cache strategy in CI for a faster speed by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/606
### :arrow_up: Dependency Updates
* chore(deps-dev): bump the dev-dependencies group across 1 directory with 3 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/604


**Full Changelog**: https://github.com/lumirlumir/npm-clang-format-node/compare/v3.0.1...v3.0.2