### PR TITLE
chore(release): bump package versions from `v3.0.2` to `v3.0.3` (`patch`)

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -12,6 +12,6 @@
     "unformatted:cpp:dry-run": "clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.2"
+    "clang-format-node": "^3.0.3"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -7,6 +7,6 @@
     "git-clang-format": "git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.2"
+    "clang-format-git": "^3.0.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-clang-format-node",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-clang-format-node",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "workspaces": [
         "examples/*",
         "packages/*",
@@ -34,13 +34,13 @@
     "examples/clang-format": {
       "name": "examples-clang-format",
       "dependencies": {
-        "clang-format-node": "^3.0.2"
+        "clang-format-node": "^3.0.3"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
       "dependencies": {
-        "clang-format-git": "^3.0.2"
+        "clang-format-git": "^3.0.3"
       }
     },
     "node_modules/@actions/core": {
@@ -10030,11 +10030,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.2"
+        "clang-format-node": "^3.0.3"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -10048,11 +10048,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.2"
+        "clang-format-node": "^3.0.3"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -10066,7 +10066,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -10083,25 +10083,25 @@
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
       "dependencies": {
-        "clang-format-git": "^3.0.2",
-        "clang-format-git-python": "^3.0.2",
-        "clang-format-node": "^3.0.2"
+        "clang-format-git": "^3.0.3",
+        "clang-format-git-python": "^3.0.3",
+        "clang-format-node": "^3.0.3"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
       "dependencies": {
-        "clang-format-git": "^3.0.2",
-        "clang-format-git-python": "^3.0.2",
-        "clang-format-node": "^3.0.2"
+        "clang-format-git": "^3.0.3",
+        "clang-format-git-python": "^3.0.3",
+        "clang-format-node": "^3.0.3"
       }
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
       "dependencies": {
-        "clang-format-git": "^3.0.2",
-        "clang-format-git-python": "^3.0.2",
-        "clang-format-node": "^3.0.2"
+        "clang-format-git": "^3.0.3",
+        "clang-format-git-python": "^3.0.3",
+        "clang-format-node": "^3.0.3"
       }
     },
     "website": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-clang-format-node",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "type": "module",
   "packageManager": "npm@11.11.0",
   "engines": {

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -59,6 +59,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.2"
+    "clang-format-node": "^3.0.3"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -58,6 +58,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.2"
+    "clang-format-node": "^3.0.3"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.2",
-    "clang-format-git-python": "^3.0.2",
-    "clang-format-node": "^3.0.2"
+    "clang-format-git": "^3.0.3",
+    "clang-format-git-python": "^3.0.3",
+    "clang-format-node": "^3.0.3"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.2",
-    "clang-format-git-python": "^3.0.2",
-    "clang-format-node": "^3.0.2"
+    "clang-format-git": "^3.0.3",
+    "clang-format-git-python": "^3.0.3",
+    "clang-format-node": "^3.0.3"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -5,8 +5,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.2",
-    "clang-format-git-python": "^3.0.2",
-    "clang-format-node": "^3.0.2"
+    "clang-format-git": "^3.0.3",
+    "clang-format-git-python": "^3.0.3",
+    "clang-format-node": "^3.0.3"
   }
 }


### PR DESCRIPTION
## Release Information: `v3.0.3`

New release of `lumirlumir/npm-clang-format-node` has arrived! :tada:

This PR bumps the package versions from `v3.0.2` to `v3.0.3` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-clang-format-node/actions/runs/24756447841) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-clang-format-node` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 2cbfd2c       |
| Old Version | `v3.0.2`  |
| New Version | `v3.0.3`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(deps): bump LLVM from llvmorg-22.1.3 to llvmorg-22.1.4 by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/616
### :toolbox: Chores
* chore(sync-server): update CI script and rename config file extensions by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/613
* chore(*): rename GitHub Actions workflows by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/615
### :arrows_counterclockwise: Continuous Integrations
* ci(*): (perf) remove unnecessary `npx` prefixes by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/612
* ci(sync-server): merge lint and test workflow configs into ci by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/614
### :arrow_up: Dependency Updates
* chore(deps-dev): bump the dev-dependencies group across 2 directories with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/609
* chore(deps-dev): bump the dev-dependencies group across 2 directories with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/610
* chore(deps-dev): bump typescript from 6.0.2 to 6.0.3 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/611


**Full Changelog**: https://github.com/lumirlumir/npm-clang-format-node/compare/v3.0.2...v3.0.3