### PR TITLE
chore(release): bump package versions from `v3.0.3` to `v3.0.4` (`patch`)

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -12,6 +12,6 @@
     "unformatted:cpp:dry-run": "clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.3"
+    "clang-format-node": "^3.0.4"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -7,6 +7,6 @@
     "git-clang-format": "git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.3"
+    "clang-format-git": "^3.0.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-clang-format-node",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-clang-format-node",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "workspaces": [
         "examples/*",
         "packages/*",
@@ -34,13 +34,13 @@
     "examples/clang-format": {
       "name": "examples-clang-format",
       "dependencies": {
-        "clang-format-node": "^3.0.3"
+        "clang-format-node": "^3.0.4"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
       "dependencies": {
-        "clang-format-git": "^3.0.3"
+        "clang-format-git": "^3.0.4"
       }
     },
     "node_modules/@actions/core": {
@@ -1556,9 +1556,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1573,9 +1570,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1590,9 +1584,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1607,9 +1598,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1624,9 +1612,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1641,9 +1626,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1658,9 +1640,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1675,9 +1654,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1692,9 +1668,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1709,9 +1682,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1726,9 +1696,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1743,9 +1710,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1760,9 +1724,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10625,11 +10586,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.3"
+        "clang-format-node": "^3.0.4"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -10643,11 +10604,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.3"
+        "clang-format-node": "^3.0.4"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -10661,7 +10622,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -10678,25 +10639,25 @@
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
       "dependencies": {
-        "clang-format-git": "^3.0.3",
-        "clang-format-git-python": "^3.0.3",
-        "clang-format-node": "^3.0.3"
+        "clang-format-git": "^3.0.4",
+        "clang-format-git-python": "^3.0.4",
+        "clang-format-node": "^3.0.4"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
       "dependencies": {
-        "clang-format-git": "^3.0.3",
-        "clang-format-git-python": "^3.0.3",
-        "clang-format-node": "^3.0.3"
+        "clang-format-git": "^3.0.4",
+        "clang-format-git-python": "^3.0.4",
+        "clang-format-node": "^3.0.4"
       }
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
       "dependencies": {
-        "clang-format-git": "^3.0.3",
-        "clang-format-git-python": "^3.0.3",
-        "clang-format-node": "^3.0.3"
+        "clang-format-git": "^3.0.4",
+        "clang-format-git-python": "^3.0.4",
+        "clang-format-node": "^3.0.4"
       }
     },
     "website": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-clang-format-node",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "type": "module",
   "packageManager": "npm@11.11.0",
   "engines": {

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -59,6 +59,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.3"
+    "clang-format-node": "^3.0.4"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -58,6 +58,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.3"
+    "clang-format-node": "^3.0.4"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.3",
-    "clang-format-git-python": "^3.0.3",
-    "clang-format-node": "^3.0.3"
+    "clang-format-git": "^3.0.4",
+    "clang-format-git-python": "^3.0.4",
+    "clang-format-node": "^3.0.4"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.3",
-    "clang-format-git-python": "^3.0.3",
-    "clang-format-node": "^3.0.3"
+    "clang-format-git": "^3.0.4",
+    "clang-format-git-python": "^3.0.4",
+    "clang-format-node": "^3.0.4"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -5,8 +5,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.3",
-    "clang-format-git-python": "^3.0.3",
-    "clang-format-node": "^3.0.3"
+    "clang-format-git": "^3.0.4",
+    "clang-format-git-python": "^3.0.4",
+    "clang-format-node": "^3.0.4"
   }
 }


### PR DESCRIPTION
## Release Information: `v3.0.4`

New release of `lumirlumir/npm-clang-format-node` has arrived! :tada:

This PR bumps the package versions from `v3.0.3` to `v3.0.4` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-clang-format-node/actions/runs/25664014565) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-clang-format-node` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 722780e       |
| Old Version | `v3.0.3`  |
| New Version | `v3.0.4`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(deps): bump LLVM from llvmorg-22.1.4 to llvmorg-22.1.5 by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/625
### :arrow_up: Dependency Updates
* chore(deps-dev): bump eslint-markdown from 0.6.1 to 0.7.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/618
* chore(deps-dev): bump postcss from 8.5.6 to 8.5.12 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/619
* chore(deps-dev): bump rollup from 4.53.3 to 4.60.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/621
* chore(deps): bump vite by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/620
* chore(deps-dev): bump eslint-markdown from 0.7.0 to 0.8.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/622
* chore(deps-dev): bump the dev-dependencies group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/624


**Full Changelog**: https://github.com/lumirlumir/npm-clang-format-node/compare/v3.0.3...v3.0.4