### PR TITLE
chore(release): bump package versions from `v3.0.5` to `v3.0.6` (`patch`)

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -12,6 +12,6 @@
     "unformatted:cpp:dry-run": "clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.5"
+    "clang-format-node": "^3.0.6"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -7,6 +7,6 @@
     "git-clang-format": "git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.5"
+    "clang-format-git": "^3.0.6"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-clang-format-node",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-clang-format-node",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "workspaces": [
         "examples/*",
         "packages/*",
@@ -34,13 +34,13 @@
     "examples/clang-format": {
       "name": "examples-clang-format",
       "dependencies": {
-        "clang-format-node": "^3.0.5"
+        "clang-format-node": "^3.0.6"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
       "dependencies": {
-        "clang-format-git": "^3.0.5"
+        "clang-format-git": "^3.0.6"
       }
     },
     "node_modules/@actions/core": {
@@ -10641,11 +10641,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "3.0.5",
+      "version": "3.0.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.5"
+        "clang-format-node": "^3.0.6"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -10659,11 +10659,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "3.0.5",
+      "version": "3.0.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.5"
+        "clang-format-node": "^3.0.6"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -10677,7 +10677,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "3.0.5",
+      "version": "3.0.6",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -10694,25 +10694,25 @@
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
       "dependencies": {
-        "clang-format-git": "^3.0.5",
-        "clang-format-git-python": "^3.0.5",
-        "clang-format-node": "^3.0.5"
+        "clang-format-git": "^3.0.6",
+        "clang-format-git-python": "^3.0.6",
+        "clang-format-node": "^3.0.6"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
       "dependencies": {
-        "clang-format-git": "^3.0.5",
-        "clang-format-git-python": "^3.0.5",
-        "clang-format-node": "^3.0.5"
+        "clang-format-git": "^3.0.6",
+        "clang-format-git-python": "^3.0.6",
+        "clang-format-node": "^3.0.6"
       }
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
       "dependencies": {
-        "clang-format-git": "^3.0.5",
-        "clang-format-git-python": "^3.0.5",
-        "clang-format-node": "^3.0.5"
+        "clang-format-git": "^3.0.6",
+        "clang-format-git-python": "^3.0.6",
+        "clang-format-node": "^3.0.6"
       }
     },
     "website": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-clang-format-node",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "type": "module",
   "packageManager": "npm@11.12.1",
   "engines": {

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -59,6 +59,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.5"
+    "clang-format-node": "^3.0.6"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [
@@ -58,6 +58,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.5"
+    "clang-format-node": "^3.0.6"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.5",
-    "clang-format-git-python": "^3.0.5",
-    "clang-format-node": "^3.0.5"
+    "clang-format-git": "^3.0.6",
+    "clang-format-git-python": "^3.0.6",
+    "clang-format-node": "^3.0.6"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.5",
-    "clang-format-git-python": "^3.0.5",
-    "clang-format-node": "^3.0.5"
+    "clang-format-git": "^3.0.6",
+    "clang-format-git-python": "^3.0.6",
+    "clang-format-node": "^3.0.6"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -5,8 +5,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.5",
-    "clang-format-git-python": "^3.0.5",
-    "clang-format-node": "^3.0.5"
+    "clang-format-git": "^3.0.6",
+    "clang-format-git-python": "^3.0.6",
+    "clang-format-node": "^3.0.6"
   }
 }


### PR DESCRIPTION
## Release Information: `v3.0.6`

New release of `lumirlumir/npm-clang-format-node` has arrived! :tada:

This PR bumps the package versions from `v3.0.5` to `v3.0.6` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-clang-format-node/actions/runs/27140334865) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-clang-format-node` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | c37c6c5       |
| Old Version | `v3.0.5`  |
| New Version | `v3.0.6`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(deps): bump LLVM from llvmorg-22.1.6 to llvmorg-22.1.7 by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/644
### :toolbox: Chores
* chore(sync-server): update eslint.config.js by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/639
### :arrow_up: Dependency Updates
* chore(deps-dev): bump eslint-config-bananass from 0.6.1 to 0.7.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/638
* chore(deps-dev): bump eslint-markdown from 0.9.1 to 0.10.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/640
* chore(deps-dev): bump @types/node from 24.12.4 to 24.13.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/641
* chore(deps): bump codecov/codecov-action from 6 to 7 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/642


**Full Changelog**: https://github.com/lumirlumir/npm-clang-format-node/compare/v3.0.5...v3.0.6