### PR TITLE
perf(*): declare packages as commonjs to avoid ambiguous module detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "release:publish": "node -e \"require('child_process').execSync('npm publish -w packages ' + (require('./package.json').version.includes('-') ? '--tag next' : ''), { stdio: 'inherit' })\"",
     "release:version": "node ./scripts/version.js",
     "coverage": "c8 --reporter=lcov npm run test",
-    "test": "npm run test -ws --if-present",
+    "test": "npm run test --workspaces --if-present",
     "test:pkg:cfg": "npm run test -w packages/clang-format-git",
     "test:pkg:cfgp": "npm run test -w packages/clang-format-git-python",
     "test:pkg:cfn": "npm run test -w packages/clang-format-node",

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clang-format-git-python",
   "version": "3.0.6",
+  "type": "commonjs",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
   "files": [

--- a/packages/clang-format-git-python/src/index.test.js
+++ b/packages/clang-format-git-python/src/index.test.js
@@ -6,16 +6,29 @@
 // Require
 // --------------------------------------------------------------------------------
 
-const { ok } = require('node:assert');
+const { ok, strictEqual } = require('node:assert');
 const { describe, it } = require('node:test');
 
 const { gitClangFormatPath, clangFormatGitPythonPath } = require('./index');
+const { type } = require('../package.json');
 
 // --------------------------------------------------------------------------------
 // Test
 // --------------------------------------------------------------------------------
 
 describe('index', () => {
+  describe('package.json', () => {
+    /*
+     * [Module syntax detection](https://nodejs.org/api/packages.html#determining-module-system) attempts to detect ESM syntax,
+     * and re-run as an ES module when no "type" field is present. It was enabled by default in Node.js v20.19.0 and Node.js v22.7.0.
+     * Detection increases startup time for ES modules, so Node is encouraging everyone -- especially package authors --
+     * to add a type field to `package.json`, even for the default `"type": "commonjs"`.
+     */
+    it('should have `type: "commonjs"`', () => {
+      strictEqual(type, 'commonjs');
+    });
+  });
+
   it('gitClangFormatPath should be imported correctly', () => {
     ok(gitClangFormatPath);
   });

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clang-format-git",
   "version": "3.0.6",
+  "type": "commonjs",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
   "files": [

--- a/packages/clang-format-git/src/index.test.js
+++ b/packages/clang-format-git/src/index.test.js
@@ -6,7 +6,7 @@
 // Require
 // --------------------------------------------------------------------------------
 
-const { ok } = require('node:assert');
+const { ok, strictEqual } = require('node:assert');
 const { describe, it } = require('node:test');
 
 const {
@@ -15,12 +15,25 @@ const {
   gitClangFormatPath,
   clangFormatGitPath,
 } = require('./index');
+const { type } = require('../package.json');
 
 // --------------------------------------------------------------------------------
 // Test
 // --------------------------------------------------------------------------------
 
 describe('index', () => {
+  describe('package.json', () => {
+    /*
+     * [Module syntax detection](https://nodejs.org/api/packages.html#determining-module-system) attempts to detect ESM syntax,
+     * and re-run as an ES module when no "type" field is present. It was enabled by default in Node.js v20.19.0 and Node.js v22.7.0.
+     * Detection increases startup time for ES modules, so Node is encouraging everyone -- especially package authors --
+     * to add a type field to `package.json`, even for the default `"type": "commonjs"`.
+     */
+    it('should have `type: "commonjs"`', () => {
+      strictEqual(type, 'commonjs');
+    });
+  });
+
   it('getGitClangFormatPath should be imported correctly', () => {
     ok(getGitClangFormatPath);
   });

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clang-format-node",
   "version": "3.0.6",
+  "type": "commonjs",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",
   "files": [

--- a/packages/clang-format-node/src/index.test.js
+++ b/packages/clang-format-node/src/index.test.js
@@ -6,7 +6,7 @@
 // Require
 // --------------------------------------------------------------------------------
 
-const { ok } = require('node:assert');
+const { ok, strictEqual } = require('node:assert');
 const { describe, it } = require('node:test');
 
 const {
@@ -15,12 +15,25 @@ const {
   getClangFormatPath,
   getClangFormatNodePath,
 } = require('./index');
+const { type } = require('../package.json');
 
 // --------------------------------------------------------------------------------
 // Test
 // --------------------------------------------------------------------------------
 
 describe('index', () => {
+  describe('package.json', () => {
+    /*
+     * [Module syntax detection](https://nodejs.org/api/packages.html#determining-module-system) attempts to detect ESM syntax,
+     * and re-run as an ES module when no "type" field is present. It was enabled by default in Node.js v20.19.0 and Node.js v22.7.0.
+     * Detection increases startup time for ES modules, so Node is encouraging everyone -- especially package authors --
+     * to add a type field to `package.json`, even for the default `"type": "commonjs"`.
+     */
+    it('should have `type: "commonjs"`', () => {
+      strictEqual(type, 'commonjs');
+    });
+  });
+
   it('clangFormatPath should be imported correctly', () => {
     ok(clangFormatPath);
   });


### PR DESCRIPTION
## Summary

- Declare each published package as CommonJS with `"type": "commonjs"`.
- Add package-level tests that assert the CommonJS type field remains present.
- Replace the root test script's short workspace flag with the explicit `--workspaces` form.

## Why

Node.js syntax detection treats `.js` files without an explicit package `type` as ambiguous input. Declaring CommonJS removes that ambiguity for these packages and documents the intended module system.
