### PR TITLE
chore(release): bump package versions from `v3.0.6` to `v3.0.7` (`patch`)

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -12,6 +12,6 @@
     "unformatted:cpp:dry-run": "clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.6"
+    "clang-format-node": "^3.0.7"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -7,6 +7,6 @@
     "git-clang-format": "git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.6"
+    "clang-format-git": "^3.0.7"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-clang-format-node",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-clang-format-node",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "workspaces": [
         "examples/*",
         "packages/*",
@@ -34,13 +34,13 @@
     "examples/clang-format": {
       "name": "examples-clang-format",
       "dependencies": {
-        "clang-format-node": "^3.0.6"
+        "clang-format-node": "^3.0.7"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
       "dependencies": {
-        "clang-format-git": "^3.0.6"
+        "clang-format-git": "^3.0.7"
       }
     },
     "node_modules/@actions/core": {
@@ -10520,11 +10520,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "3.0.6",
+      "version": "3.0.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.6"
+        "clang-format-node": "^3.0.7"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -10538,11 +10538,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "3.0.6",
+      "version": "3.0.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.6"
+        "clang-format-node": "^3.0.7"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -10556,7 +10556,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "3.0.6",
+      "version": "3.0.7",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -10573,25 +10573,25 @@
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
       "dependencies": {
-        "clang-format-git": "^3.0.6",
-        "clang-format-git-python": "^3.0.6",
-        "clang-format-node": "^3.0.6"
+        "clang-format-git": "^3.0.7",
+        "clang-format-git-python": "^3.0.7",
+        "clang-format-node": "^3.0.7"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
       "dependencies": {
-        "clang-format-git": "^3.0.6",
-        "clang-format-git-python": "^3.0.6",
-        "clang-format-node": "^3.0.6"
+        "clang-format-git": "^3.0.7",
+        "clang-format-git-python": "^3.0.7",
+        "clang-format-node": "^3.0.7"
       }
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
       "dependencies": {
-        "clang-format-git": "^3.0.6",
-        "clang-format-git-python": "^3.0.6",
-        "clang-format-node": "^3.0.6"
+        "clang-format-git": "^3.0.7",
+        "clang-format-git-python": "^3.0.7",
+        "clang-format-node": "^3.0.7"
       }
     },
     "website": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-clang-format-node",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "type": "module",
   "packageManager": "npm@11.12.1",
   "engines": {

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "type": "commonjs",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
@@ -60,6 +60,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.6"
+    "clang-format-node": "^3.0.7"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "type": "commonjs",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
@@ -59,6 +59,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.6"
+    "clang-format-node": "^3.0.7"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "type": "commonjs",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.6",
-    "clang-format-git-python": "^3.0.6",
-    "clang-format-node": "^3.0.6"
+    "clang-format-git": "^3.0.7",
+    "clang-format-git-python": "^3.0.7",
+    "clang-format-node": "^3.0.7"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.6",
-    "clang-format-git-python": "^3.0.6",
-    "clang-format-node": "^3.0.6"
+    "clang-format-git": "^3.0.7",
+    "clang-format-git-python": "^3.0.7",
+    "clang-format-node": "^3.0.7"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -5,8 +5,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.6",
-    "clang-format-git-python": "^3.0.6",
-    "clang-format-node": "^3.0.6"
+    "clang-format-git": "^3.0.7",
+    "clang-format-git-python": "^3.0.7",
+    "clang-format-node": "^3.0.7"
   }
 }


### PR DESCRIPTION
## Release Information: `v3.0.7`

New release of `lumirlumir/npm-clang-format-node` has arrived! :tada:

This PR bumps the package versions from `v3.0.6` to `v3.0.7` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-clang-format-node/actions/runs/28091066323) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-clang-format-node` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 89273d4       |
| Old Version | `v3.0.6`  |
| New Version | `v3.0.7`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(deps): bump LLVM from llvmorg-22.1.7 to llvmorg-22.1.8 by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/655
### :memo: Documentation
* docs(website): update `vitepress` to latest by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/651
### :zap: Performance Improvements
* perf(*): declare packages as commonjs to avoid ambiguous module detection by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/650
### :arrow_up: Dependency Updates
* chore(deps-dev): bump the dev-dependencies group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/646
* chore(deps-dev): bump the dev-dependencies group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/649
* chore(deps-dev): bump shell-quote from 1.8.3 to 1.8.4 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/648
* chore(deps-dev): bump markdownlint-cli from 0.48.0 to 0.49.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/652
* chore(deps-dev): bump undici from 6.26.0 to 6.27.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/656


**Full Changelog**: https://github.com/lumirlumir/npm-clang-format-node/compare/v3.0.6...v3.0.7