### PR TITLE
build(*): add TypeScript project references and incremental builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "precoverage": "node -e \"require('node:fs').mkdirSync('coverage', { recursive: true })\"",
     "coverage": "node --test --experimental-test-coverage --test-coverage-exclude=\"**/build/**\" --test-coverage-exclude=\"**/*.test.{js,mjs,cjs}\" --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info",
     "test": "node --test",
+    "test:types": "tsc -b",
     "test:pkg:cfg": "npm run test -w packages/clang-format-git",
     "test:pkg:cfgp": "npm run test -w packages/clang-format-git-python",
     "test:pkg:cfn": "npm run test -w packages/clang-format-node",

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -54,7 +54,7 @@
   "scripts": {
     "postinstall": "node chmod.js || exit 0",
     "prepublishOnly": "npm run build",
-    "build": "tsc --emitDeclarationOnly false && node ../../scripts/cp.js ../../LICENSE.md LICENSE.md ../../README.md README.md",
+    "build": "tsc -b tsconfig.build.json && node ../../scripts/cp.js ../../LICENSE.md LICENSE.md ../../README.md README.md",
     "test": "node --test",
     "dev": "node src/cli.js",
     "start": "node build/cli.js"

--- a/packages/clang-format-git-python/tsconfig.build.json
+++ b/packages/clang-format-git-python/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.build.json",
+  "references": [
+    {
+      "path": "../clang-format-node/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    /* Modules */
+    "types": ["node"]
+  }
+}

--- a/packages/clang-format-git-python/tsconfig.json
+++ b/packages/clang-format-git-python/tsconfig.json
@@ -1,21 +1,8 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "src/**/*.js",
-    "src/**/*.mjs",
-    "src/**/*.cjs",
-    "src/**/*.jsx",
-    "src/**/*.ts",
-    "src/**/*.mts",
-    "src/**/*.cts",
-    "src/**/*.tsx"
-  ],
-  "exclude": ["src/**/*.test.js", "src/**/*.test.ts", "**/fixtures/**"],
-  "compilerOptions": {
-    /* Modules */
-    "rootDir": "./src",
-
-    /* Emit */
-    "outDir": "build"
-  }
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "postinstall": "node chmod.js || exit 0",
     "prepublishOnly": "npm run build",
-    "build": "tsc --emitDeclarationOnly false && node ../../scripts/cp.js ../../LICENSE.md LICENSE.md ../../README.md README.md",
+    "build": "tsc -b tsconfig.build.json && node ../../scripts/cp.js ../../LICENSE.md LICENSE.md ../../README.md README.md",
     "test": "node --test",
     "dev": "node src/cli.js",
     "start": "node build/cli.js"

--- a/packages/clang-format-git/tsconfig.build.json
+++ b/packages/clang-format-git/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.build.json",
+  "references": [
+    {
+      "path": "../clang-format-node/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    /* Modules */
+    "types": ["node"]
+  }
+}

--- a/packages/clang-format-git/tsconfig.json
+++ b/packages/clang-format-git/tsconfig.json
@@ -1,21 +1,8 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "src/**/*.js",
-    "src/**/*.mjs",
-    "src/**/*.cjs",
-    "src/**/*.jsx",
-    "src/**/*.ts",
-    "src/**/*.mts",
-    "src/**/*.cts",
-    "src/**/*.tsx"
-  ],
-  "exclude": ["src/**/*.test.js", "src/**/*.test.ts", "**/fixtures/**"],
-  "compilerOptions": {
-    /* Modules */
-    "rootDir": "./src",
-
-    /* Emit */
-    "outDir": "build"
-  }
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "postinstall": "node chmod.js || exit 0",
     "prepublishOnly": "npm run build",
-    "build": "tsc --emitDeclarationOnly false && node ../../scripts/cp.js ../../LICENSE.md LICENSE.md ../../README.md README.md",
+    "build": "tsc -b tsconfig.build.json && node ../../scripts/cp.js ../../LICENSE.md LICENSE.md ../../README.md README.md",
     "test": "node --test",
     "dev": "node src/cli.js",
     "start": "node build/cli.js"

--- a/packages/clang-format-node/tsconfig.build.json
+++ b/packages/clang-format-node/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.build.json",
+  "references": [],
+  "compilerOptions": {
+    /* Modules */
+    "types": ["node"]
+  }
+}

--- a/packages/clang-format-node/tsconfig.json
+++ b/packages/clang-format-node/tsconfig.json
@@ -1,21 +1,8 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "src/**/*.js",
-    "src/**/*.mjs",
-    "src/**/*.cjs",
-    "src/**/*.jsx",
-    "src/**/*.ts",
-    "src/**/*.mts",
-    "src/**/*.cts",
-    "src/**/*.tsx"
-  ],
-  "exclude": ["src/**/*.test.js", "src/**/*.test.ts", "**/fixtures/**"],
-  "compilerOptions": {
-    /* Modules */
-    "rootDir": "./src",
-
-    /* Emit */
-    "outDir": "build"
-  }
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ]
 }

--- a/tsconfig.base.build.json
+++ b/tsconfig.base.build.json
@@ -1,0 +1,36 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [
+    "${configDir}/src/**/*.js",
+    "${configDir}/src/**/*.mjs",
+    "${configDir}/src/**/*.cjs",
+    "${configDir}/src/**/*.jsx",
+    "${configDir}/src/**/*.ts",
+    "${configDir}/src/**/*.mts",
+    "${configDir}/src/**/*.cts",
+    "${configDir}/src/**/*.tsx"
+  ],
+  "exclude": [
+    "${configDir}/src/**/*.test.js",
+    "${configDir}/src/**/*.test.mjs",
+    "${configDir}/src/**/*.test.cjs",
+    "${configDir}/src/**/*.test.jsx",
+    "${configDir}/src/**/*.test.ts",
+    "${configDir}/src/**/*.test.mts",
+    "${configDir}/src/**/*.test.cts",
+    "${configDir}/src/**/*.test.tsx",
+    "${configDir}/src/**/*.test-d.ts",
+    "${configDir}/src/**/*.test-d.mts",
+    "${configDir}/src/**/*.test-d.cts",
+    "${configDir}/src/**/*.test-d.tsx",
+    "${configDir}/**/fixtures/**"
+  ],
+  "compilerOptions": {
+    /* Emit */
+    "emitDeclarationOnly": false,
+    "outDir": "${configDir}/build",
+
+    /* Projects */
+    "tsBuildInfoFile": "${configDir}/.tsbuildinfo/tsconfig.build.tsbuildinfo"
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,9 +23,10 @@
     "useUnknownInCatchVariables": true,
 
     /* Modules */
-    "module": "NodeNext",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
-    "types": ["node"],
+    "rootDir": "${configDir}/src",
+    "types": [],
 
     /* Emit */
     "declaration": true,
@@ -41,6 +42,11 @@
     "verbatimModuleSyntax": true,
 
     /* Language and Environment */
-    "target": "ESNext"
+    "target": "esnext",
+
+    /* Projects */
+    "composite": true,
+    "incremental": true,
+    "tsBuildInfoFile": "${configDir}/.tsbuildinfo/tsconfig.tsbuildinfo"
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./packages/clang-format-git/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/clang-format-git-python/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/clang-format-node/tsconfig.build.json"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./packages/clang-format-git/tsconfig.json"
+    },
+    {
+      "path": "./packages/clang-format-git-python/tsconfig.json"
+    },
+    {
+      "path": "./packages/clang-format-node/tsconfig.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,34 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [
+    "**/*.config.js",
+    "**/*.config.mjs",
+    "**/*.config.cjs",
+    "**/*.config.ts",
+    "**/*.config.mts",
+    "**/*.config.cts",
+    "**/plugins/**/*.js",
+    "**/plugins/**/*.mjs",
+    "**/plugins/**/*.cjs",
+    "**/plugins/**/*.ts",
+    "**/plugins/**/*.mts",
+    "**/plugins/**/*.cts",
+    "**/scripts/**/*.js",
+    "**/scripts/**/*.mjs",
+    "**/scripts/**/*.cjs",
+    "**/scripts/**/*.ts",
+    "**/scripts/**/*.mts",
+    "**/scripts/**/*.cts"
+  ],
+  "compilerOptions": {
+    /* Modules */
+    "rootDir": ".",
+    "types": ["node"],
+
+    /* Emit */
+    "noEmit": true,
+
+    /* Completeness */
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
This pull request refactors the TypeScript build configuration for the monorepo to use project references and shared base configs, improving build performance, maintainability, and type safety. Each package now has a dedicated `tsconfig.build.json` extending a new root build config, and the main `tsconfig.json` files are simplified to reference these build configs. The build scripts are updated accordingly, and new root-level configs are added for build orchestration and scripts.

**TypeScript Build System Refactor**

* Introduced a new shared `tsconfig.base.build.json` with standardized `include`, `exclude`, and output settings, used by all package build configs for consistency.
* Each package (`clang-format-git`, `clang-format-git-python`, `clang-format-node`) now has its own `tsconfig.build.json` extending the shared base and declaring dependencies via project references. [[1]](diffhunk://#diff-cd4400752e0a9b5ee99b14530e0442cb1cbd406ca8efb2da0163534782115dc8R1-R12) [[2]](diffhunk://#diff-d7de711d2a8b48e71983c2e1f16ae4429d69da8ed8104a661543859cf7c4a959R1-R8)
* Package `tsconfig.json` files are simplified to reference their respective `tsconfig.build.json`, removing direct include/exclude and compiler options.

**Build and Test Script Updates**

* Updated `build` scripts in all package `package.json` files to use `tsc -b tsconfig.build.json` for incremental, project-referenced builds. [[1]](diffhunk://#diff-fb0eb5dba5b2656b3fdea4322c2ed2a691973f2e9ea536ce20b36c347ab1267eL57-R57) [[2]](diffhunk://#diff-d85dcfb0934f579cff896723ab5eeb9a52668d2bb322338dddd93bc1241aa4f1L56-R56) [[3]](diffhunk://#diff-6e04d643c57b851ab02ad78e41531387d2cc01caf6c4cfbaa536aadd37346a30L55-R55)
* Added a new root `test:types` script to run `tsc -b` for type checking across the monorepo.

**Monorepo and Node Tooling**

* Added a root-level `tsconfig.build.json` and `tsconfig.build.json` references file to orchestrate builds across all packages.
* Added a new `tsconfig.node.json` for scripts, configs, and plugins, with appropriate includes and Node types.

**General TypeScript Config Improvements**

* Updated `tsconfig.base.json` with improved compiler options, including `composite`, `incremental`, and monorepo-friendly settings. [[1]](diffhunk://#diff-0b280a445be167f54cd916c0718c952b8e0d4ca9621903d05eec25efd4c6ed6dL26-R29) [[2]](diffhunk://#diff-0b280a445be167f54cd916c0718c952b8e0d4ca9621903d05eec25efd4c6ed6dL44-R50)

These changes streamline TypeScript builds, enable faster incremental compilation, and lay the groundwork for better cross-package type safety and developer experience.