### PR TITLE
docs(website): update documentation contents to the latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Node wrapper for LLVM Clang's `clang-format` and `git-clang-format` native binar
 
 For full documentation, see the [official documentation of the `clang-format-node`](https://clang-format-node.lumir.page).
 
-## Binary Security
+## Fully Secure Binaries
 
 Binaries are built directly from the [official LLVM project source code](https://github.com/llvm/llvm-project). No third-party binaries are used; everything is built from scratch using [GitHub Actions](https://github.com/lumirlumir/npm-clang-format-node/blob/main/.github/workflows/llvm-build-bump-pr.yml).
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Node wrapper for LLVM Clang's `clang-format` and `git-clang-format` native binar
 
 For full documentation, see the [official documentation of the `clang-format-node`](https://clang-format-node.lumir.page).
 
-## Fully Secure Binaries
+## Binary Security
 
 Binaries are built directly from the [official LLVM project source code](https://github.com/llvm/llvm-project). No third-party binaries are used; everything is built from scratch using [GitHub Actions](https://github.com/lumirlumir/npm-clang-format-node/blob/main/.github/workflows/llvm-build-bump-pr.yml).
 
-All binaries are fully verified by [GitHub Actions Attestation Provenances](https://github.com/lumirlumir/npm-clang-format-node/attestations) and [npm Build Provenances](https://docs.npmjs.com/generating-provenance-statements).
+All binaries can be verified using [GitHub Actions provenance attestations](https://github.com/lumirlumir/npm-clang-format-node/attestations), and published packages include [npm provenance](https://docs.npmjs.com/generating-provenance-statements).
 
 For more information, please refer to the [Security](https://github.com/lumirlumir/npm-clang-format-node/blob/main/SECURITY.md) page.
 
@@ -70,7 +70,7 @@ Each package intends to release a new npm package for every **latest** release o
 
 Thanks for having attention to this package🙇‍♂️. We appreciate you spending the time to work on these things. Every issue and pull request about bugs, suggestions and the other topics is always welcome!
 
-Please read our [Code of Conduct](https://github.com/lumirlumir/.github/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct) and [Contributing](https://github.com/lumirlumir/npm-clang-format-node/blob/main/CONTRIBUTING.md) Guides before you work on these things. We also recommend you to read the [Guides on LLVM `clang-format`](http://clang-format-node.lumir.page/docs/further-reading/guides-on-llvm-clang-format) mentioned in the documentation before contributing.
+Please read our [Code of Conduct](https://github.com/lumirlumir/.github/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct) and [Contributing](https://github.com/lumirlumir/npm-clang-format-node/blob/main/CONTRIBUTING.md) Guides before you work on these things. We also recommend you to read the [Guides on LLVM `clang-format`](https://clang-format-node.lumir.page/docs/further-reading/guides-on-llvm-clang-format) mentioned in the documentation before contributing.
 
 ## Code of Conduct
 
@@ -82,7 +82,7 @@ See [Change Log](https://github.com/lumirlumir/npm-clang-format-node/blob/main/C
 
 ## Versioning
 
-See [Versioning](http://clang-format-node.lumir.page/docs/community/versioning).
+See [Versioning](https://clang-format-node.lumir.page/docs/community/versioning).
 
 ## Security
 
@@ -90,4 +90,4 @@ See [Security](https://github.com/lumirlumir/npm-clang-format-node/blob/main/SEC
 
 ## License
 
-[MIT](https://github.com/lumirlumir/npm-clang-format-node/blob/main/LICENSE.md) under [LLVM Apache License 2.0](https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT).
+Project source is [MIT licensed](https://github.com/lumirlumir/npm-clang-format-node/blob/main/LICENSE.md); bundled LLVM-derived components use the [Apache License 2.0 with LLVM Exceptions](https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,17 +13,17 @@ Some may have concerns about the security of binary files, but the following poi
     - See [`llvm-build-bump-pr.yml`](https://github.com/lumirlumir/npm-clang-format-node/blob/main/.github/workflows/llvm-build-bump-pr.yml).
     - See the [Pull Request list on GitHub](https://github.com/lumirlumir/npm-clang-format-node/pulls?q=is%3Apr+%28deps%29%3A+%22bump+LLVM+from%22+label%3Adependencies+).
 
-1. All binaries are fully verified by [GitHub Actions Attestation Provenances](https://github.com/lumirlumir/npm-clang-format-node/attestations) and [npm Build Provenances](https://docs.npmjs.com/generating-provenance-statements).
+1. All binaries can be verified using [GitHub Actions provenance attestations](https://github.com/lumirlumir/npm-clang-format-node/attestations), and published packages include [npm provenance](https://docs.npmjs.com/generating-provenance-statements).
 
 1. When you run the command `clang-format --version`, you can verify the current **LLVM version**, **repository URL**, and **commit SHA**, as shown below:
 
     ```sh
-    clang-format version 18.1.8 (https://github.com/llvm/llvm-project 3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff)
+    clang-format version 22.1.8 (https://github.com/llvm/llvm-project ca7933e47d3a3451d81e72ac174dcb5aa28b59d1)
     ```
 
-    - `18.1.8`: The current LLVM version.
+    - `22.1.8`: The current LLVM version.
     - `https://github.com/llvm/llvm-project`: The Git repository URL for the LLVM project, which includes Clang.
-    - `3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff`: The commit hash for the specific version used to build `clang-format`, allowing you to trace the source code exactly.
+    - `ca7933e47d3a3451d81e72ac174dcb5aa28b59d1`: The commit hash for the specific version used to build `clang-format`, allowing you to trace the source code exactly.
 
 ## Reporting a Vulnerability
 

--- a/website/docs/apis/clang-format-git-python.md
+++ b/website/docs/apis/clang-format-git-python.md
@@ -7,6 +7,8 @@
 
 Node wrapper for `git-clang-format` Python script. <u>**This package requires Python3 as a dependency**</u>.
 
+The CLI invokes a command named `python`, so ensure that `python --version` resolves to Python 3 in your environment.
+
 > [!TIP]
 >
 > This package also supports JSDoc type hints with the following APIs, so you'll see more detailed information directly in your code editor.
@@ -31,9 +33,16 @@ $ pnpm add -g clang-format-git-python
 $ pnpm add -D clang-format-git-python
 ```
 
-```sh [yarn]
+```sh [yarn v1]
 # Global
 $ yarn global add clang-format-git-python
+# Local
+$ yarn add --dev clang-format-git-python
+```
+
+```sh [yarn v2+]
+# Run without adding to the project
+$ yarn dlx clang-format-git-python
 # Local
 $ yarn add --dev clang-format-git-python
 ```
@@ -65,7 +74,7 @@ npx clang-format-git-python
 
 ## Node.js APIs
 
-These APIs depends on the Node.js `fs` and `path` module and the file system, so you cannot use it in browsers.
+These APIs depend on the Node.js `fs` and `path` modules and the file system, so you cannot use them in browsers.
 
 - CommonJS
 

--- a/website/docs/apis/clang-format-git.md
+++ b/website/docs/apis/clang-format-git.md
@@ -31,9 +31,16 @@ $ pnpm add -g clang-format-git
 $ pnpm add -D clang-format-git
 ```
 
-```sh [yarn]
+```sh [yarn v1]
 # Global
 $ yarn global add clang-format-git
+# Local
+$ yarn add --dev clang-format-git
+```
+
+```sh [yarn v2+]
+# Run without adding to the project
+$ yarn dlx clang-format-git
 # Local
 $ yarn add --dev clang-format-git
 ```
@@ -65,7 +72,7 @@ npx clang-format-git
 
 ## Node.js APIs
 
-These APIs depends on the Node.js `fs` and `path` module and the file system, so you cannot use it in browsers.
+These APIs depend on the Node.js `fs` and `path` modules and the file system, so you cannot use them in browsers.
 
 - CommonJS
 

--- a/website/docs/apis/clang-format-node.md
+++ b/website/docs/apis/clang-format-node.md
@@ -31,9 +31,16 @@ $ pnpm add -g clang-format-node
 $ pnpm add -D clang-format-node
 ```
 
-```sh [yarn]
+```sh [yarn v1]
 # Global
 $ yarn global add clang-format-node
+# Local
+$ yarn add --dev clang-format-node
+```
+
+```sh [yarn v2+]
+# Run without adding to the project
+$ yarn dlx clang-format-node
 # Local
 $ yarn add --dev clang-format-node
 ```
@@ -65,7 +72,7 @@ npx clang-format-node
 
 ## Node.js APIs
 
-These APIs depends on the Node.js `fs` and `path` module and the file system, so you cannot use it in browsers.
+These APIs depend on the Node.js `fs` and `path` modules and the file system, so you cannot use them in browsers.
 
 - CommonJS
 

--- a/website/docs/blog/v1.2.0.md
+++ b/website/docs/blog/v1.2.0.md
@@ -8,6 +8,10 @@ head:
 
 # Release of v1.2.0 {#release-of-v1-2-0}
 
+> [!NOTE]
+>
+> This is a historical release post. For current versions and support details, see [GitHub Releases](https://github.com/lumirlumir/npm-clang-format-node/releases) and the [Supported](../get-started/supported.md) page.
+
 I'm excited to share the new release of `clang-format-node` v1.2.0, a formatter for C, C++, Java, JavaScript, JSON, Objective-C, Protobuf, and C#, built on Clang for the Node.js environment. This project is a fresh take, inspired by Angular's deprecated [`clang-format`](https://github.com/angular/clang-format) package.
 
 I previously introduced this project to the open source community a month or two ago , but I'm sharing it again as it has become even more stable and new features have been added. Thanks to the interest and support from the community, and the adoption by legacy users, the package recently hit over 10,000 weekly downloads. I am deeply grateful for this support.

--- a/website/docs/further-reading/about-os-platform-and-os-arch-in-nodejs.md
+++ b/website/docs/further-reading/about-os-platform-and-os-arch-in-nodejs.md
@@ -4,7 +4,7 @@ description: "Explanation of `os.platform()` and `os.arch()` in Node.js with ret
 
 # About `os.platform()` and `os.arch()` in Node.js
 
-## [`os.platform()`](https://nodejs.org/docs/v20.17.0/api/os.html#osplatform)
+## [`os.platform()`](https://nodejs.org/api/os.html#osplatform)
 
 The return value is equivalent to `process.platform`.
 
@@ -14,7 +14,7 @@ macOS   | `darwin`                           |
 Linux   | `linux`                            |
 Windows | `win32`                            |
 
-## [`os.arch()`](https://nodejs.org/docs/v20.17.0/api/os.html#osarch)
+## [`os.arch()`](https://nodejs.org/api/os.html#osarch)
 
 The return value is equivalent to `process.arch`.
 

--- a/website/docs/further-reading/build-process.md
+++ b/website/docs/further-reading/build-process.md
@@ -12,13 +12,13 @@ You can build `clang-format` native binary on Linux using the script below.
 sudo apt-get update -y
 sudo apt-get install -y git python3 g++ cmake ninja-build
 
-# Replace llvmorg-18.1.8 with your desired version. Check the tags at https://github.com/llvm/llvm-project/tags
-git clone --depth 1 --branch llvmorg-18.1.8 https://github.com/llvm/llvm-project.git
+# Replace llvmorg-22.1.8 with your desired version. Check the tags at https://github.com/llvm/llvm-project/tags
+git clone --depth 1 --branch llvmorg-22.1.8 https://github.com/llvm/llvm-project.git
 cd llvm-project
 
-cmake -S llvm -B build-linux-x64 -G Ninja \
+cmake -S llvm -B build -G Ninja \
   -DLLVM_ENABLE_PROJECTS="clang" \
-  -DCMAKE_BUILD_TYPE=MinSizeRel \
+  -DCMAKE_BUILD_TYPE=MinSizeRel
 
 ninja -C build clang-format
 

--- a/website/docs/further-reading/guides-on-llvm-clang-format.md
+++ b/website/docs/further-reading/guides-on-llvm-clang-format.md
@@ -7,7 +7,7 @@ description: "A collection of useful documentation and guide links related to LL
 If you want to learn more about LLVM `clang-format`, check out the links below.
 
 - [LLVM GitHub Repository](https://github.com/llvm/llvm-project)
-- [LLVM Download Page](https://releases.llvm.org/download.html)
+- [LLVM Download Page](https://github.com/llvm/llvm-project/releases/latest)
 - [LLVM `git-clang-format` Python Script](https://github.com/llvm/llvm-project/blob/main/clang/tools/clang-format/git-clang-format)
 - [Clang-Format Style Options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)
 - [Clang-Format CLI](https://clang.llvm.org/docs/ClangFormat.html)

--- a/website/docs/get-started/cli.md
+++ b/website/docs/get-started/cli.md
@@ -51,11 +51,11 @@ If you want to learn more about `clang-format` itself, see the [Clang-Format Sty
     Output example
 
     ```sh
-    clang-format version 18.1.8 (https://github.com/llvm/llvm-project 3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff)
+    clang-format version 22.1.8 (https://github.com/llvm/llvm-project ca7933e47d3a3451d81e72ac174dcb5aa28b59d1)
     ```
 
     - `https://github.com/llvm/llvm-project`: The Git repository URL for the LLVM project, which includes Clang.
-    - `3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff`: The commit hash for the specific version used to build `clang-format`, allowing you to trace the source code exactly.
+    - `ca7933e47d3a3451d81e72ac174dcb5aa28b59d1`: The commit hash for the specific version used to build `clang-format`, allowing you to trace the source code exactly.
 
 1. `--help`: Help view additional options.
 
@@ -63,7 +63,7 @@ If you want to learn more about `clang-format` itself, see the [Clang-Format Sty
     npx clang-format --help
     ```
 
-1. `--dry-run` or `-n`: Makes an **WARNING** when `example.cpp` is not correctly formatted.
+1. `--dry-run` or `-n`: Reports a **warning** when `example.cpp` is not correctly formatted.
 
     `--dry-run` and `-n` options are equivalent.
 
@@ -75,7 +75,7 @@ If you want to learn more about `clang-format` itself, see the [Clang-Format Sty
     npx clang-format -n example.cpp
     ```
 
-1. `-Werror --dry-run` or `-Werror -n`: Makes an **ERROR** when `example.cpp` is not correctly formatted.
+1. `-Werror --dry-run` or `-Werror -n`: Reports an **error** when `example.cpp` is not correctly formatted.
 
     > [!TIP]
     >
@@ -103,11 +103,11 @@ If you want to learn more about `clang-format` itself, see the [Clang-Format Sty
 
 ### Glob patterns
 
-Unfortunately, there is no way to apply `clang-format` recursively. `*.cpp` will only match files in the current directory, not subdirectories. Even `**/*` doesn't work.
+`clang-format` itself does not search for files recursively. `*.cpp` will only match files in the current directory, not subdirectories. Whether `**/*` works depends on your shell and its settings.
 
-**So, you need to use the `find` command in POSIX.** If you are a Windows user, use ***git bash***. then you can use the `find` command. The `find` command recursively searches through directories.
+**So, you can use the `find` command in POSIX.** If you are a Windows user, use ***Git Bash***. Then you can use the `find` command. The `find` command recursively searches through directories.
 
-It is simple but can produce an error if the [**Argument list is too long**](https://stackoverflow.com/questions/11289551/argument-list-too-long-error-for-rm-cp-mv-commands). In that case, use `xargs`
+Using command substitution is simple but can produce an [**Argument list is too long**](https://stackoverflow.com/questions/11289551/argument-list-too-long-error-for-rm-cp-mv-commands) error. In that case, use `xargs`.
 
 1. Basic
 
@@ -145,7 +145,7 @@ It is simple but can produce an error if the [**Argument list is too long**](htt
 >
 > This feature is included in the [`clang-format-git`](../apis/clang-format-git.md) and [`clang-format-git-python`](../apis/clang-format-git-python.md) package.
 
-`clang-format-git` and `clang-format-git-python` are two options for using `git-clang-format`, so you can choose the one that best fits your setup. The usage is same to ['angular/clang-format'](https://github.com/angular/clang-format).
+`clang-format-git` and `clang-format-git-python` are two options for using `git-clang-format`, so you can choose the one that best fits your setup. The usage is the same as [angular/clang-format](https://github.com/angular/clang-format), which is no longer maintained.
 
 ---
 

--- a/website/docs/get-started/configuration.md
+++ b/website/docs/get-started/configuration.md
@@ -24,7 +24,7 @@ my-project/
 
 ### Monorepo
 
-If you are using monorepo, you can place the configuration file in the root of the monorepo.
+In a monorepo, place a shared configuration at the repository root or a package-specific configuration inside a package. `clang-format` uses the closest configuration in an input file's parent directories.
 
 ```sh {8,9}
 my-monorepo/
@@ -65,7 +65,7 @@ You can use the `.clang-format` file to configure the style of your code. Here i
     ColumnLimit: 90
     ```
 
-- Advanced:
+- Advanced (snapshots; use the linked repository files as the current source):
 
     ::: details Node.js project's configuration. See [Node.js repository](https://github.com/nodejs/node/blob/main/.clang-format).
 

--- a/website/docs/get-started/ignore-files.md
+++ b/website/docs/get-started/ignore-files.md
@@ -19,6 +19,7 @@ You can create `.clang-format-ignore` files to make `clang-format` ignore certai
 - The slash (`/`) is used as the directory separator.
 - A pattern is relative to the directory of the `.clang-format-ignore` file (or the root directory if the pattern starts with a slash). Patterns containing drive names (e.g. `C:`) are not supported.
 - Patterns follow the rules specified in [**POSIX 2.13.1, 2.13.2, and Rule 1 of 2.13.3.**](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13)
+- Bash globstar (`**`) is supported.
 - A pattern is negated if it starts with a bang (`!`).
 
 To match all files in a directory, use e.g. `foo/bar/*`. To match all files in the directory of the `.clang-format-ignore` file, use `*`. Multiple `.clang-format-ignore` files are supported similar to the `.clang-format` files, with a lower directory level file voiding the higher level ones.

--- a/website/docs/get-started/installation.md
+++ b/website/docs/get-started/installation.md
@@ -4,6 +4,8 @@ description: "Installation instructions for `clang-format-node`, `clang-format-g
 
 # Installation {#installation}
 
+All three packages require Node.js 16 or later.
+
 ## `clang-format-node` - <small>[Repository](https://github.com/lumirlumir/npm-clang-format-node/tree/main/packages/clang-format-node) | [npm](https://www.npmjs.com/package/clang-format-node)</small> {#clang-format-node}
 
 [![NPM Version](https://img.shields.io/npm/v/clang-format-node)](https://www.npmjs.com/package/clang-format-node)&nbsp;
@@ -27,9 +29,16 @@ $ pnpm add -g clang-format-node
 $ pnpm add -D clang-format-node
 ```
 
-```sh [yarn]
+```sh [yarn v1]
 # Global
 $ yarn global add clang-format-node
+# Local
+$ yarn add --dev clang-format-node
+```
+
+```sh [yarn v2+]
+# Run without adding to the project
+$ yarn dlx clang-format-node
 # Local
 $ yarn add --dev clang-format-node
 ```
@@ -66,9 +75,16 @@ $ pnpm add -g clang-format-git
 $ pnpm add -D clang-format-git
 ```
 
-```sh [yarn]
+```sh [yarn v1]
 # Global
 $ yarn global add clang-format-git
+# Local
+$ yarn add --dev clang-format-git
+```
+
+```sh [yarn v2+]
+# Run without adding to the project
+$ yarn dlx clang-format-git
 # Local
 $ yarn add --dev clang-format-git
 ```
@@ -105,9 +121,16 @@ $ pnpm add -g clang-format-git-python
 $ pnpm add -D clang-format-git-python
 ```
 
-```sh [yarn]
+```sh [yarn v1]
 # Global
 $ yarn global add clang-format-git-python
+# Local
+$ yarn add --dev clang-format-git-python
+```
+
+```sh [yarn v2+]
+# Run without adding to the project
+$ yarn dlx clang-format-git-python
 # Local
 $ yarn add --dev clang-format-git-python
 ```

--- a/website/docs/get-started/introduction.md
+++ b/website/docs/get-started/introduction.md
@@ -94,7 +94,7 @@ This ensures that the changes you've made are properly formatted!
 
 ### Formatting a Single Commit
 
-By default, `git-clang-format` formats changed lines in the working tree. The workflow is simple:
+By default, `git-clang-format` formats staged changes and applies the formatting to the working tree. The workflow is simple:
 
 1. Write and edit your files however you like (it's okay to be messy).
 1. Stage your changes using `git add`.
@@ -174,4 +174,4 @@ You can use `git-clang-format` with a `pre-commit` hook to format your code befo
 
 `clang-format` is a powerful tool, but its real-world application often requires more than just running `clang-format -i`. For most developers, the practical approach is to use `git-clang-format` to format only the specific changes in your pull request.
 
-Since `git-clang-format` works on the working tree by default, it's easy to review formatting changes separately from development changes. This makes code reviews smoother and helps you maintain a clean, professional codebase without sacrificing flexibility during development. Whether you're tidying up a single commit or an entire branch, a few additional Git commands can go a long way toward keeping your formatting clean and reviewers happy.
+Since `git-clang-format` applies formatting changes to the working tree by default, it's easy to review them separately from staged development changes. This makes code reviews smoother and helps you maintain a clean, professional codebase without sacrificing flexibility during development. Whether you're tidying up a single commit or an entire branch, a few additional Git commands can go a long way toward keeping your formatting clean and reviewers happy.

--- a/website/docs/get-started/introduction.md
+++ b/website/docs/get-started/introduction.md
@@ -94,7 +94,7 @@ This ensures that the changes you've made are properly formatted!
 
 ### Formatting a Single Commit
 
-`git-clang-format` operates on staged changes. The workflow is simple:
+By default, `git-clang-format` formats changed lines in the working tree. The workflow is simple:
 
 1. Write and edit your files however you like (it's okay to be messy).
 1. Stage your changes using `git add`.
@@ -155,11 +155,11 @@ Here's an example:
     +int main() {} # [!code ++]
     ```
 
-This workflow allows you to review `clang-format`'s changes independently of your development changes. If you don't like them, you can discard them by purging your working tree using `git checkout`. If you're satisfied, simply stage the formatting changes with `git add`.
+This workflow allows you to review `clang-format`'s changes independently of your development changes. If you don't like them, you can discard them from the working tree using `git restore <file>`. If you're satisfied, simply stage the formatting changes with `git add`.
 
 ### Specifying a Formatting Style
 
-You can customize the formatting style using the `--style` option. Predefined styles include `LLVM`, `Google`, `Chromium`, `Mozilla`, and `WebKit`. If your project has a `.clang-format` file, you can use it by specifying `file` as the style:
+You can customize the formatting style using the `--style` option. Predefined styles include `LLVM`, `GNU`, `Google`, `Chromium`, `Microsoft`, `Mozilla`, and `WebKit`. If your project has a `.clang-format` file, you can use it by specifying `file` as the style:
 
 ```sh
 $ git-clang-format --style=WebKit
@@ -174,4 +174,4 @@ You can use `git-clang-format` with a `pre-commit` hook to format your code befo
 
 `clang-format` is a powerful tool, but its real-world application often requires more than just running `clang-format -i`. For most developers, the practical approach is to use `git-clang-format` to format only the specific changes in your pull request.
 
-Since `git-clang-format` works on the staging tree, it's easy to review formatting changes separately from development changes. This makes code reviews smoother and helps you maintain a clean, professional codebase without sacrificing flexibility during development. Whether you're tidying up a single commit or an entire branch, a few additional Git commands can go a long way toward keeping your formatting clean and reviewers happy.
+Since `git-clang-format` works on the working tree by default, it's easy to review formatting changes separately from development changes. This makes code reviews smoother and helps you maintain a clean, professional codebase without sacrificing flexibility during development. Whether you're tidying up a single commit or an entire branch, a few additional Git commands can go a long way toward keeping your formatting clean and reviewers happy.

--- a/website/docs/get-started/migration-from-angular-clang-format.md
+++ b/website/docs/get-started/migration-from-angular-clang-format.md
@@ -22,7 +22,7 @@ npx clang-format -Werror -n example.cpp
 
 ## `git-clang-format`
 
-> `v1.2.0 (llvmorg-19.1.3)` - latest
+> `v1.2.0 (llvmorg-19.1.3)` and later
 
 This feature has been supported since [`v1.2.0 (llvmorg-19.1.3)`](https://github.com/lumirlumir/npm-clang-format-node/releases/tag/v1.2.0), so migration is no longer necessary. Instead, you can use the [`clang-format-git`](../apis/clang-format-git.md) or [`clang-format-git-python`](../apis/clang-format-git-python.md) package.
 

--- a/website/docs/get-started/q-and-a.md
+++ b/website/docs/get-started/q-and-a.md
@@ -9,7 +9,7 @@ description: Questions and answers about clang-format-node.
 > [!NOTE] References
 >
 > - [Why are the results of `clang-format` and `git-clang-format` different?](https://stackoverflow.com/questions/76968316/why-are-the-results-of-clang-format-and-git-clang-format-different) on Stack Overflow.
-> - [Git Intergration](https://clang.llvm.org/docs/ClangFormat.html#git-integration) on LLVM Clang.
+> - [Git Integration](https://clang.llvm.org/docs/ClangFormat.html#git-integration) on LLVM Clang.
 
 `git-clang-format` only formats changes. `clang-format` formats the whole document.
 

--- a/website/docs/get-started/supported.md
+++ b/website/docs/get-started/supported.md
@@ -8,18 +8,18 @@ The following content applies to all packages within [`clang-format-node`](https
 
 ## OS Platforms and Architectures
 
-Each package supports **ALL** [**Tier1**](https://github.com/nodejs/node/blob/main/BUILDING.md#strategy) and some [**Tier2**](https://github.com/nodejs/node/blob/main/BUILDING.md#strategy) platforms of Node.js. *Note that the functionality cannot be guaranteed on platforms which is not mentioned below*.
+Each package supports **ALL** [**Tier 1**](https://github.com/nodejs/node/blob/main/BUILDING.md#strategy) and some [**Tier 2**](https://github.com/nodejs/node/blob/main/BUILDING.md#strategy) platforms of Node.js. *Note that the functionality cannot be guaranteed on platforms that are not mentioned below*.
 
 (To see the full list of platforms supported by Node.js, click [here](<https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list>).)
 
 <br> | Operating System | Architectures    | Support Type |
 ---- | ---------------- | ---------------- | ------------ |
 1    | macOS            | arm64            | Tier 1       |
-2    | macOS            | x64              | Tier 1       |
-3    | GNU/Linux        | armv7            | Tier 1       |
+2    | macOS            | x64              | Tier 2       |
+3    | GNU/Linux        | armv7            | Experimental |
 4    | GNU/Linux        | arm64            | Tier 1       |
-5    | GNU/Linux        | ppc64le >=power8 | Tier 2       |
-6    | GNU/Linux        | s390x            | Tier 2       |
+5    | GNU/Linux        | ppc64le >=power9 | Tier 2       |
+6    | GNU/Linux        | s390x >=z14      | Tier 2       |
 7    | GNU/Linux        | x64              | Tier 1       |
 8    | Windows          | x64              | Tier 1       |
 
@@ -29,10 +29,9 @@ Each package supports **ALL** [**Tier1**](https://github.com/nodejs/node/blob/ma
 >
 > 1. Or you can download `clang-format` native binary from [LLVM release assets](https://github.com/llvm/llvm-project/releases) that match your operating system platform and architecture like the lists below.
 >
->     - `clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz`
->     - `clang+llvm-18.1.8-armv7a-linux-gnueabihf.tar.gz`
->     - `clang+llvm-18.1.8-powerpc64-ibm-aix-7.2.tar.xz`
->     - `clang+llvm-18.1.8-x86_64-pc-windows-msvc.tar.xz`
+>     - `LLVM-22.1.8-Linux-ARM64.tar.xz`
+>     - `clang+llvm-22.1.8-armv7a-linux-gnueabihf.tar.gz`
+>     - `clang+llvm-22.1.8-x86_64-pc-windows-msvc.tar.xz`
 >     - and more...
 
 ## Node.js Version
@@ -41,32 +40,26 @@ Each package supports **ALL** [**Tier1**](https://github.com/nodejs/node/blob/ma
 
 The official support for <u>**Node.js version 16 and above**</u> has been confirmed through [testing](https://github.com/lumirlumir/npm-clang-format-node/blob/main/.github/workflows/test.yml).
 
-However, this package does not utilize the latest features of Node.js. Therefore, it is expected to work on versions significantly lower than the officially supported ones. (ex. `"node": ">=4.0.0"`) Consequently, **if the current package operates on a version of Node.js that is lower than the officially supported version, it should be perfectly fine to use.**
+Earlier versions of Node.js may still work, but versions below Node.js 16 are not tested or officially supported.
 
 ## [GitHub Actions Runner Images](https://github.com/actions/runner-images?tab=readme-ov-file#available-images)
 
 If you want to use `clang-format-node` or `clang-format-git` in continuous integration (CI), You can use **GitHub Actions**. The following basic runner images are compatible(available) with `clang-format-node`.
 
-Image                        | YAML Label                                                             | Included Software |
----------------------------- | ---------------------------------------------------------------------- | ----------------- |
-macOS 15                     | `macos-15-large`                                                       | macOS-15          |
-macOS 15 Arm64               | `macos-15` or `macos-15-xlarge`                                        | macOS-15-arm64    |
-macOS 14                     | `macos-latest-large` or `macos-14-large`                               | macOS-14          |
-macOS 14 Arm64               | `macos-latest`, `macos-14`, `macos-latest-xlarge` or `macos-14-xlarge` | macOS-14-arm64    |
-Ubuntu 24.04                 | `ubuntu-latest` or `ubuntu-24.04`                                      | ubuntu-24.04      |
-Ubuntu 22.04                 | `ubuntu-22.04`                                                         | ubuntu-22.04      |
-Windows Server 2022          | `windows-latest` or `windows-2022`                                     | windows-2022      |
-
-However, the following basic runner images are **NOT** compatible(available) with `clang-format-node`. It's because the ***dependencies*** for LLVM's latest release version are not compatible with the following images.
-
-Image                   | YAML Label     | Included Software |
------------------------ | -------------- | ----------------- |
-~~Ubuntu 20.04~~        | `ubuntu-20.04` | ubuntu-20.04      |
-~~Windows Server 2019~~ | `windows-2019` | windows-2019      |
+Image                        | YAML Label                                  | Included Software |
+---------------------------- | ------------------------------------------- | ----------------- |
+macOS 15                     | `macos-15-large`                            | macOS-15          |
+macOS 15 Arm64               | `macos-15` or `macos-15-xlarge`             | macOS-15-arm64    |
+macOS 14                     | `macos-14-large`                            | macOS-14          |
+macOS 14 Arm64               | `macos-14` or `macos-14-xlarge`             | macOS-14-arm64    |
+Ubuntu 24.04                 | `ubuntu-latest` or `ubuntu-24.04`           | ubuntu-24.04      |
+Ubuntu 22.04                 | `ubuntu-22.04`                              | ubuntu-22.04      |
+Windows Server 2025          | `windows-latest` or `windows-2025`          | windows-2025      |
+Windows Server 2022          | `windows-2022`                              | windows-2022      |
 
 ## Docker Build Images
 
-We used the following Images to build `clang-format` excuatable binaries.
+We used the following images to build `clang-format` executable binaries.
 
 > [!TIP]
 >

--- a/website/docs/get-started/use-with-husky-and-lint-staged.md
+++ b/website/docs/get-started/use-with-husky-and-lint-staged.md
@@ -4,27 +4,27 @@ description: "Guide to integrating `clang-format` with `husky` and `lint-staged`
 
 # Use with `husky` and `lint-staged`
 
-Ensuring that changes to your code are properly formatted is an important part of your development workflow. Use [`husky`](https://typicode.github.io/husky/) and [`lint-staged`](https://github.com/lint-staged/lint-staged) for your continuous integration process.
+Ensuring that changes to your code are properly formatted is an important part of your development workflow. Use [`husky`](https://typicode.github.io/husky/) and [`lint-staged`](https://github.com/lint-staged/lint-staged) for a local pre-commit check.
 
-## `husky` <Badge type="warning" text="v8.x" />
+## `husky`
 
 ```sh [.husky/pre-commit]
 npx lint-staged
 ```
 
-## `lint-staged` <Badge type="warning" text="v15.x" />
+## `lint-staged`
 
 1. Check
 
     > [!TIP]
     >
-    > If `example1.cpp` and `example2.c` are staged, then `npx clang-format -Werror -n example1.cpp example2.c` will be excuted.
+    > If `example1.cpp` and `example2.c` are staged, then `npx clang-format -Werror -n example1.cpp example2.c` will be executed.
 
     ```json [package.json] {3-5}
     {
       // ...
       "lint-staged": {
-        "*.{c,cpp,h}": "npx clang-format -Werror -n",
+        "*.{c,cpp,h}": "npx clang-format -Werror -n"
       }
       // ...
     }
@@ -36,7 +36,7 @@ npx lint-staged
     {
       // ...
       "lint-staged": {
-        "*.{c,cpp,h}": "npx clang-format -i",
+        "*.{c,cpp,h}": "npx clang-format -i"
       }
       // ...
     }

--- a/website/docs/get-started/why-we-started-this-project.md
+++ b/website/docs/get-started/why-we-started-this-project.md
@@ -4,7 +4,7 @@ description: "Learn why this project was created as a maintained alternative to 
 
 # Why we started this project
 
-['angular/clang-format'](https://github.com/angular/clang-format) is no longer maintained (See [#79](https://github.com/angular/clang-format/issues/79) [#82](https://github.com/angular/clang-format/issues/82) [#83](https://github.com/angular/clang-format/pull/83)). Nevertheless, new versions of `clang-format` continue to be released. Bugs are fixed, and new features are added. However, using `clang-format` directly in a Node.js environment without any support can be somewhat cumbersome. So we decided to make a new, maintained version of it.
+['angular/clang-format'](https://github.com/angular/clang-format) is no longer maintained; it was archived on October 17, 2025, and is read-only (See [#79](https://github.com/angular/clang-format/issues/79) [#82](https://github.com/angular/clang-format/issues/82) [#83](https://github.com/angular/clang-format/pull/83)). Nevertheless, new versions of `clang-format` continue to be released. Bugs are fixed, and new features are added. However, using `clang-format` directly in a Node.js environment without any support can be somewhat cumbersome. So we decided to make a new, maintained version of it.
 
 And also, `git-clang-format` relies on **Python3**, so if you haven't installed Python, they cannot be executed. Many people would prefer if this package worked without dependencies beyond Node.js. **So, this package relies only on Node.js.** However, for the compatability with previous users of [angular/clang-format](https://github.com/angular/clang-format) and those who prefer to use this package with Python3, alternative options for using `git-clang-format` are also provided.
 

--- a/website/index.md
+++ b/website/index.md
@@ -4,8 +4,8 @@ title: clang-format-node
 
 hero:
   name: clang-format-node
-  text: Node wrapper for LLVM Clang Project's <code>clang-format</code> and <code>git-clang-format</code> native binaries.
-  tagline: C, C++, Java, JavaScript, JSON, Objective-C, Protobuf, and C# formatter based on Clang for Node.js environment.🐉
+  text: High-performance source code formatter for C, C++, Java, JavaScript, JSON, Objective-C, Protobuf, and C# based on clang-format
+  tagline: A Node.js wrapper for LLVM's native <code>clang-format</code> and <code>git-clang-format</code> binaries.🐉
   image:
     light: /logo-white.svg
     dark: /logo-black.svg


### PR DESCRIPTION
This pull request updates documentation and installation guides across multiple files to improve clarity, accuracy, and support for modern package managers. The most important changes are summarized below.

---

**Installation and Package Manager Support**

* Added explicit support and instructions for Yarn v2+ (`yarn dlx`) in installation guides for `clang-format-node`, `clang-format-git`, and `clang-format-git-python`, ensuring users can install and run the packages with the latest Yarn versions. [[1]](diffhunk://#diff-085b09b29480db7b6f10994f8f7f227fa520c8878d8781cb37a282658383eba0L30-R45) [[2]](diffhunk://#diff-04beae9bb51a72d869a908ccaa14f0c2dd5b67e6a13c2e9e98e2e6bf7a4f2106L34-R47) [[3]](diffhunk://#diff-98645b0798262ab3ff2b1e08fc0dd324499f5bb87274d4f15b58e9c3da3e79e0L34-R47) [[4]](diffhunk://#diff-5060a3c67544aaba0c41aeee2e68442e779de26fa17d0129b8de744b4ed1fb34L34-R49)
* Clarified that all three packages require Node.js 16 or later.

**Documentation and Usage Improvements**

* Updated code examples and documentation to reference LLVM version 22.1.8 and its commit hash, replacing the previous 18.1.8 references, and clarified the verification process for binaries. [[1]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L16-R26) [[2]](diffhunk://#diff-81166f9f84b58bd0a8f63481798d341e895c493b6efe2eec867d43cb5d160ed1L54-R66)
* Improved explanations around recursive file matching and the use of glob patterns, with clearer guidance for Windows users and details on shell compatibility.
* Added a note to the v1.2.0 release blog post clarifying its historical nature and directing users to current release/support information.

**Link and Reference Corrections**

* Updated outdated or incorrect links to use HTTPS and point to the latest or more relevant resources (e.g., Node.js API docs, LLVM releases, versioning, and guides). [[1]](diffhunk://#diff-cd0642b526ba5f7226a37aab45eaaa35043ecda2fc9d11bf614ca8616dc71265L7-R7) [[2]](diffhunk://#diff-cd0642b526ba5f7226a37aab45eaaa35043ecda2fc9d11bf614ca8616dc71265L17-R17) [[3]](diffhunk://#diff-f172823378971ff999696cfbd6c4b734efb9d1da46da559d7e177da98ffdd9d3L10-R10) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R73) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L85-R93)

**Configuration and Ignore File Enhancements**

* Clarified monorepo configuration guidance and how `clang-format` selects configuration files.
* Noted that Bash globstar (`**`) is supported in `.clang-format-ignore` patterns.

**General Style and Accuracy Improvements**

* Improved language for accuracy and consistency, such as replacing "Makes an ERROR" with "Reports an error" and correcting module references to plural forms. [[1]](diffhunk://#diff-81166f9f84b58bd0a8f63481798d341e895c493b6efe2eec867d43cb5d160ed1L78-R78) [[2]](diffhunk://#diff-5060a3c67544aaba0c41aeee2e68442e779de26fa17d0129b8de744b4ed1fb34L68-R77) [[3]](diffhunk://#diff-98645b0798262ab3ff2b1e08fc0dd324499f5bb87274d4f15b58e9c3da3e79e0L68-R75) [[4]](diffhunk://#diff-04beae9bb51a72d869a908ccaa14f0c2dd5b67e6a13c2e9e98e2e6bf7a4f2106L68-R75)
* Clarified licensing language in the README.

These changes collectively enhance the usability, accuracy, and maintainability of the documentation and onboarding experience for users and contributors.