### PR TITLE
chore(*): sync node and npm versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=24.15.0"
+        "node": ">=24.18.0"
       }
     },
     "examples/clang-format": {

--- a/package.json
+++ b/package.json
@@ -3,19 +3,19 @@
   "name": "npm-clang-format-node",
   "version": "3.0.7",
   "type": "module",
-  "packageManager": "npm@11.12.1",
+  "packageManager": "npm@11.16.0",
   "engines": {
-    "node": ">=24.15.0"
+    "node": ">=24.18.0"
   },
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": ">=24.15.0",
+      "version": ">=24.18.0",
       "onFail": "error"
     },
     "packageManager": {
       "name": "npm",
-      "version": ">=11.12.1",
+      "version": ">=11.16.0",
       "onFail": "error"
     }
   },

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npm run build",
+  "buildCommand": "node -v && npm run build",
   "cleanUrls": true,
   "framework": "vitepress",
   "ignoreCommand": "node ../scripts/vercel-ignore-command.js",


### PR DESCRIPTION
## Summary

- Set the minimum Node.js development version to 24.18.0.
- Set the npm development version to 11.16.0.
- Synchronize the root package-lock metadata.

## Validation

- Not run per request.