### PR TITLE
chore(release): bump package versions from `v3.0.7` to `v4.0.0` (`major`)

### DIFF
--- a/examples/clang-format/package.json
+++ b/examples/clang-format/package.json
@@ -12,6 +12,6 @@
     "unformatted:cpp:dry-run": "clang-format -Werror -n src/unformatted.cpp"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.7"
+    "clang-format-node": "^4.0.0"
   }
 }

--- a/examples/git-clang-format/package.json
+++ b/examples/git-clang-format/package.json
@@ -7,6 +7,6 @@
     "git-clang-format": "git-clang-format"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.7"
+    "clang-format-git": "^4.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-clang-format-node",
-  "version": "3.0.7",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-clang-format-node",
-      "version": "3.0.7",
+      "version": "4.0.0",
       "workspaces": [
         "examples/*",
         "packages/*",
@@ -33,13 +33,13 @@
     "examples/clang-format": {
       "name": "examples-clang-format",
       "dependencies": {
-        "clang-format-node": "^3.0.7"
+        "clang-format-node": "^4.0.0"
       }
     },
     "examples/git-clang-format": {
       "name": "examples-git-clang-format",
       "dependencies": {
-        "clang-format-git": "^3.0.7"
+        "clang-format-git": "^4.0.0"
       }
     },
     "node_modules/@actions/core": {
@@ -9100,11 +9100,11 @@
       }
     },
     "packages/clang-format-git": {
-      "version": "3.0.7",
+      "version": "4.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.7"
+        "clang-format-node": "^4.0.0"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -9118,11 +9118,11 @@
       }
     },
     "packages/clang-format-git-python": {
-      "version": "3.0.7",
+      "version": "4.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^3.0.7"
+        "clang-format-node": "^4.0.0"
       },
       "bin": {
         "clang-format-git-python": "build/cli.js",
@@ -9136,7 +9136,7 @@
       }
     },
     "packages/clang-format-node": {
-      "version": "3.0.7",
+      "version": "4.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9153,25 +9153,25 @@
     "tests/integration-api-cjs": {
       "name": "tests-integration-api-cjs",
       "dependencies": {
-        "clang-format-git": "^3.0.7",
-        "clang-format-git-python": "^3.0.7",
-        "clang-format-node": "^3.0.7"
+        "clang-format-git": "^4.0.0",
+        "clang-format-git-python": "^4.0.0",
+        "clang-format-node": "^4.0.0"
       }
     },
     "tests/integration-api-esm": {
       "name": "tests-integration-api-esm",
       "dependencies": {
-        "clang-format-git": "^3.0.7",
-        "clang-format-git-python": "^3.0.7",
-        "clang-format-node": "^3.0.7"
+        "clang-format-git": "^4.0.0",
+        "clang-format-git-python": "^4.0.0",
+        "clang-format-node": "^4.0.0"
       }
     },
     "tests/integration-binaries-permission": {
       "name": "tests-integration-binaries-permission",
       "dependencies": {
-        "clang-format-git": "^3.0.7",
-        "clang-format-git-python": "^3.0.7",
-        "clang-format-node": "^3.0.7"
+        "clang-format-git": "^4.0.0",
+        "clang-format-git-python": "^4.0.0",
+        "clang-format-node": "^4.0.0"
       }
     },
     "website": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "npm-clang-format-node",
-  "version": "3.0.7",
+  "version": "4.0.0",
   "type": "module",
   "packageManager": "npm@11.16.0",
   "engines": {

--- a/packages/clang-format-git-python/package.json
+++ b/packages/clang-format-git-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git-python",
-  "version": "3.0.7",
+  "version": "4.0.0",
   "type": "commonjs",
   "description": "Node wrapper for git-clang-format Python script. This package requires Python3 as a dependency.🐉",
   "main": "build/index.js",
@@ -60,6 +60,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.7"
+    "clang-format-node": "^4.0.0"
   }
 }

--- a/packages/clang-format-git/package.json
+++ b/packages/clang-format-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-git",
-  "version": "3.0.7",
+  "version": "4.0.0",
   "type": "commonjs",
   "description": "Node wrapper for git-clang-format Python script as a standalone native binary to allow execution without a Python dependency.🐉",
   "main": "build/index.js",
@@ -59,6 +59,6 @@
     "start": "node build/cli.js"
   },
   "dependencies": {
-    "clang-format-node": "^3.0.7"
+    "clang-format-node": "^4.0.0"
   }
 }

--- a/packages/clang-format-node/package.json
+++ b/packages/clang-format-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clang-format-node",
-  "version": "3.0.7",
+  "version": "4.0.0",
   "type": "commonjs",
   "description": "Node wrapper for clang-format native binary inspired by angular/clang-format.🐉",
   "main": "build/index.js",

--- a/tests/integration-api-cjs/package.json
+++ b/tests/integration-api-cjs/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.7",
-    "clang-format-git-python": "^3.0.7",
-    "clang-format-node": "^3.0.7"
+    "clang-format-git": "^4.0.0",
+    "clang-format-git-python": "^4.0.0",
+    "clang-format-node": "^4.0.0"
   }
 }

--- a/tests/integration-api-esm/package.json
+++ b/tests/integration-api-esm/package.json
@@ -6,8 +6,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.7",
-    "clang-format-git-python": "^3.0.7",
-    "clang-format-node": "^3.0.7"
+    "clang-format-git": "^4.0.0",
+    "clang-format-git-python": "^4.0.0",
+    "clang-format-node": "^4.0.0"
   }
 }

--- a/tests/integration-binaries-permission/package.json
+++ b/tests/integration-binaries-permission/package.json
@@ -5,8 +5,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "clang-format-git": "^3.0.7",
-    "clang-format-git-python": "^3.0.7",
-    "clang-format-node": "^3.0.7"
+    "clang-format-git": "^4.0.0",
+    "clang-format-git-python": "^4.0.0",
+    "clang-format-node": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Release Information: `v4.0.0`

New release of `lumirlumir/npm-clang-format-node` has arrived! :tada:

This PR bumps the package versions from `v3.0.7` to `v4.0.0` (`major`).

See [Actions](https://github.com/lumirlumir/npm-clang-format-node/actions/runs/34024988635) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-clang-format-node` |
| SEMVER      | `major`     |
| Pre ID      | `canary`      |
| Short SHA   | c9703ed       |
| Old Version | `v3.0.7`  |
| New Version | `v4.0.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* feat(deps)!: bump LLVM from llvmorg-22.1.8 to llvmorg-23.1.0 by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/688
### :hammer_and_wrench: Builds
* build(*): add TypeScript project references and incremental builds by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/677
### :toolbox: Chores
* chore(*): migrate to nodejs native test coverage from `c8` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/658
* chore(sync-server): update `actions/checkout` by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/659
* chore(sync-server): bump actions/setup-node from 6 to 7 by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/671
* chore(website): replace Codecov plugin for Vite 7 compatibility by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/680
* chore(*): sync node and npm versions by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/682
* chore(sync-server): update `test:coverage` script by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/683
* chore(website): update `logo-og.png` image by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/684
### :memo: Documentation
* docs(website): update documentation contents to the latest by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/681
* docs(website): update website messaging and branding by @lumirlumir in https://github.com/lumirlumir/npm-clang-format-node/pull/686
### :arrow_up: Dependency Updates
* chore(deps): bump actions/checkout from 6 to 7 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/653
* chore(deps-dev): bump prettier from 3.8.4 to 3.9.1 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/660
* chore(deps-dev): bump prettier from 3.9.1 to 3.9.4 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/662
* chore(deps-dev): bump the dev-dependencies group across 1 directory with 3 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/665
* chore(deps-dev): bump the dev-dependencies group across 1 directory with 3 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/667
* chore(deps-dev): bump the dev-dependencies group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/670
* chore(deps): bump actions/setup-node from 6 to 7 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/668
* chore(deps-dev): bump postcss from 8.5.15 to 8.5.23 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/674
* chore(deps): bump actions/setup-python from 6 to 7 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/673
* chore(deps-dev): bump shell-quote from 1.8.4 to 1.10.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/672
* chore(deps-dev): bump the dev-dependencies group across 2 directories with 1 update by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/676
* chore(deps-dev): bump brace-expansion from 1.1.15 to 1.1.18 by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/678
* chore(deps-dev): bump eslint-markdown from 0.12.1 to 0.13.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/679
* chore(deps-dev): bump eslint-markdown from 0.13.0 to 0.14.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/685
* chore(deps-dev): bump editorconfig-checker from 6.1.1 to 7.0.0 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/687
* chore(deps-dev): bump eslint-markdown from 0.14.0 to 0.14.1 in the dev-dependencies group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/689
* chore(deps-dev): bump browserslist from 4.28.2 to 4.28.8 and dev-dependencies by @dependabot[bot] in https://github.com/lumirlumir/npm-clang-format-node/pull/690


**Full Changelog**: https://github.com/lumirlumir/npm-clang-format-node/compare/v3.0.7...v4.0.0